### PR TITLE
Minor documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ This Rails app doesn't use a database.
 1\. First enable software collections, checkout the code, and install the dependencies:
 
 ```
-scl enable nodejs010 rh-ruby22 git19 bash
+scl enable nodejs010 rh-ruby22 bash
 
 cd /path/to/build/directory/sys
-git clone clone git@github.com:OSC/ood-ondemand.git dashboard
+git clone https://github.com/OSC/ood-ondemand.git dashboard
 cd dashboard
-git checkout v1.0.3 # latest version
+git checkout tags/v1.0.3 # latest version
 bin/bundle install --path vendor/bundle
 ```
 


### PR DESCRIPTION
May be worth replacing initial scl command with something like this for all commands that require SCL.

```
scl enable nodejs010 rh-ruby22 -- bin/bundle install --path vendor/bundle
```

Using `scl enable nodejs010 rh-ruby22 bash` modifies root's shell in a such a way where an admin must be careful to exit that shell once done with the install.