### PR TITLE
App Groups

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,1 @@
+OOD_DATAROOT=$PWD/data

--- a/app/apps/dev_router.rb
+++ b/app/apps/dev_router.rb
@@ -1,9 +1,10 @@
 class DevRouter
-  attr_reader :name, :owner
+  attr_reader :name, :owner, :caption
 
   def initialize(name, owner=OodSupport::Process.user.name)
     @name = name
     @owner = owner
+    @caption = "Sandbox App"
   end
 
   def self.apps(owner: OodSupport::Process.user.name, require_manifest: true)

--- a/app/apps/dev_router.rb
+++ b/app/apps/dev_router.rb
@@ -1,10 +1,11 @@
 class DevRouter
-  attr_reader :name, :owner, :caption
+  attr_reader :name, :owner, :caption, :category
 
   def initialize(name, owner=OodSupport::Process.user.name)
     @name = name
     @owner = owner
     @caption = "Sandbox App"
+    @category = "Sandbox Apps"
   end
 
   def self.apps(owner: OodSupport::Process.user.name, require_manifest: true)

--- a/app/apps/manifest.rb
+++ b/app/apps/manifest.rb
@@ -1,7 +1,7 @@
 require 'yaml'
 
 class Manifest
-  attr_reader :name, :provider, :description, :group
+  attr_reader :name, :description, :category, :subcategory
 
   class InvalidContentError < StandardError
     def initialize
@@ -24,6 +24,7 @@ description: |
 
   * [Company Website](https://www.osc.edu)
 
+category: OSC
       )
     end
   end
@@ -49,7 +50,7 @@ description: |
   end
 
   def defaults
-    {"name" => "", "provider" => "", "description" => "", "group" => ""}
+    {"name" => "", "description" => "", "category" => "", "subcategory" => ""}
   end
 
   def initialize(opts)
@@ -59,9 +60,9 @@ description: |
     opts = defaults.merge(opts) { |key, oldval, newval| newval || oldval  }
 
     @name = opts.fetch("name")
-    @provider = opts.fetch("provider")
     @description = opts.fetch("description")
-    @group = opts.fetch("group")
+    @category = opts.fetch("category")
+    @subcategory = opts.fetch("subcategory")
   end
 
   def valid?

--- a/app/apps/manifest.rb
+++ b/app/apps/manifest.rb
@@ -1,7 +1,7 @@
 require 'yaml'
 
 class Manifest
-  attr_reader :name, :provider, :description
+  attr_reader :name, :provider, :description, :group
 
   class InvalidContentError < StandardError
     def initialize
@@ -49,7 +49,7 @@ description: |
   end
 
   def defaults
-    {"name" => "", "provider" => "", "description" => ""}
+    {"name" => "", "provider" => "", "description" => "", "group" => ""}
   end
 
   def initialize(opts)
@@ -61,6 +61,7 @@ description: |
     @name = opts.fetch("name")
     @provider = opts.fetch("provider")
     @description = opts.fetch("description")
+    @group = opts.fetch("group")
   end
 
   def valid?

--- a/app/apps/ood_app.rb
+++ b/app/apps/ood_app.rb
@@ -27,13 +27,12 @@ class OodApp
     manifest.name.empty? ? name.titleize : manifest.name
   end
 
-  # returns app group title or nil if no group
-  def group
-    manifest.group
-  end
-
   def has_gemfile?
     path.join("Gemfile").file? && path.join("Gemfile.lock").file?
+  end
+
+  def category
+    manifest.category.empty? ? router.category : manifest.category
   end
 
   def bundler_helper

--- a/app/apps/ood_app.rb
+++ b/app/apps/ood_app.rb
@@ -27,6 +27,11 @@ class OodApp
     manifest.name.empty? ? name.titleize : manifest.name
   end
 
+  # returns app group title or nil if no group
+  def group
+    # TODO: delegate to manifest(?)
+  end
+
   def has_gemfile?
     path.join("Gemfile").file? && path.join("Gemfile.lock").file?
   end

--- a/app/apps/ood_app.rb
+++ b/app/apps/ood_app.rb
@@ -29,7 +29,7 @@ class OodApp
 
   # returns app group title or nil if no group
   def group
-    # TODO: delegate to manifest(?)
+    manifest.group
   end
 
   def has_gemfile?

--- a/app/apps/ood_app.rb
+++ b/app/apps/ood_app.rb
@@ -1,6 +1,6 @@
 class OodApp
   attr_reader :router
-  delegate :owner, :url, :type, :path, to: :router
+  delegate :owner, :caption, :url, :type, :path, to: :router
 
   PROTECTED_NAMES = ["shared_apps", "cgi-bin", "tmp"]
 

--- a/app/apps/ood_app_group.rb
+++ b/app/apps/ood_app_group.rb
@@ -10,16 +10,12 @@ class OodAppGroup
     apps.count > 0
   end
 
-  # Givin a list of owners, we will build a list of AppGroups
-  # where each app group is a list of apps that user has shared
-  def self.usr_groups(owners)
-    Array(owners).map do |o|
-      g = OodAppGroup.new
-      g.title = (Etc.getpwnam(o).gecos || o)
-      g.subtitle = o
-      g.apps = UsrRouter.apps(owner: o)
-      g
-    end.select(&:has_apps?)
+  def self.groups_for(apps: [])
+    apps.group_by { |app|
+      app.category
+    }.map { |k,v|
+      OodAppGroup.new(title: k, apps: v)
+    }
   end
 
   # Return an array of AppGroups with the apps sorted into groups that they

--- a/app/apps/ood_app_group.rb
+++ b/app/apps/ood_app_group.rb
@@ -20,4 +20,27 @@ class OodAppGroup
       g
     end.select(&:has_apps?)
   end
+
+  # Return an array of AppGroups with the apps sorted into groups that they
+  # specify in the manifest with group title being the manifest. The default
+  # AppGroup has the same title and subtitle as this AppGroup.
+  def split
+    groups = {}
+
+    apps.each do |app|
+      key = app.group
+      key = nil if key == "" # group "" and nil together
+
+      unless groups.has_key?(key)
+        groups[key] = self.class.new.tap do |g|
+          g.title = (key || title)
+          g.subtitle = subtitle
+        end
+      end
+
+      groups[key].apps << app
+    end
+
+    groups.values
+  end
 end

--- a/app/apps/ood_app_group.rb
+++ b/app/apps/ood_app_group.rb
@@ -1,5 +1,5 @@
 class OodAppGroup
-  attr_accessor :apps, :title, :subtitle
+  attr_accessor :apps, :title
 
   def initialize(title: "", apps: [])
     @apps = apps

--- a/app/apps/ood_app_group.rb
+++ b/app/apps/ood_app_group.rb
@@ -9,13 +9,12 @@ class OodAppGroup
     apps.count > 0
   end
 
-  # TODO: write lots of tests so we can refactor this well...
+  # Givin a list of owners, we will build a list of AppGroups
+  # where each app group is a list of apps that user has shared
   def self.usr_groups(owners)
-    # TODO: this gets much more complex when we have apps specifying
-    # which groups they should be filtered under
     Array(owners).map do |o|
       g = OodAppGroup.new
-      g.title = o
+      g.title = (Etc.getpwnam(o).gecos || o)
       g.subtitle = o
       g.apps = UsrRouter.apps(owner: o)
       g

--- a/app/apps/ood_app_group.rb
+++ b/app/apps/ood_app_group.rb
@@ -1,8 +1,9 @@
 class OodAppGroup
   attr_accessor :apps, :title, :subtitle
 
-  def initialize
-    @apps = []
+  def initialize(title: "", apps: [])
+    @apps = apps
+    @title = title
   end
 
   def has_apps?

--- a/app/apps/ood_app_group.rb
+++ b/app/apps/ood_app_group.rb
@@ -17,27 +17,4 @@ class OodAppGroup
       OodAppGroup.new(title: k, apps: v)
     }
   end
-
-  # Return an array of AppGroups with the apps sorted into groups that they
-  # specify in the manifest with group title being the manifest. The default
-  # AppGroup has the same title and subtitle as this AppGroup.
-  def split
-    groups = {}
-
-    apps.each do |app|
-      key = app.category
-      key = nil if key == "" # group "" and nil together
-
-      unless groups.has_key?(key)
-        groups[key] = self.class.new.tap do |g|
-          g.title = (key || title)
-          g.subtitle = subtitle
-        end
-      end
-
-      groups[key].apps << app
-    end
-
-    groups.values
-  end
 end

--- a/app/apps/ood_app_group.rb
+++ b/app/apps/ood_app_group.rb
@@ -29,7 +29,7 @@ class OodAppGroup
     groups = {}
 
     apps.each do |app|
-      key = app.group
+      key = app.category
       key = nil if key == "" # group "" and nil together
 
       unless groups.has_key?(key)

--- a/app/apps/ood_app_group.rb
+++ b/app/apps/ood_app_group.rb
@@ -15,6 +15,6 @@ class OodAppGroup
       app.category
     }.map { |k,v|
       OodAppGroup.new(title: k, apps: v)
-    }
+    }.sort_by { |g| g.title }
   end
 end

--- a/app/apps/sys_router.rb
+++ b/app/apps/sys_router.rb
@@ -40,6 +40,10 @@ class SysRouter
     :sys
   end
 
+  def caption
+    "System Installed App"
+  end
+
   def url
     "/pun/sys/#{name}"
   end

--- a/app/apps/sys_router.rb
+++ b/app/apps/sys_router.rb
@@ -44,6 +44,10 @@ class SysRouter
     "System Installed App"
   end
 
+  def category
+    "System Installed Apps"
+  end
+
   def url
     "/pun/sys/#{name}"
   end

--- a/app/apps/usr_router.rb
+++ b/app/apps/usr_router.rb
@@ -27,7 +27,7 @@ class UsrRouter
   #
   # @param owners [String, Array<String>] owner or owners to get apps for
   # @return [Array<OodApp>] array of apps that the specified owner(s) have
-  def self.all_apps(owners: owners)
+  def self.all_apps(owners:)
     Array(owners).map { |o| UsrRouter.apps(owner: o) }.flatten
   end
 

--- a/app/apps/usr_router.rb
+++ b/app/apps/usr_router.rb
@@ -10,6 +10,10 @@ class UsrRouter
     "Shared by #{owner_title} (#{owner})"
   end
 
+  def category
+    owner_title
+  end
+
   def owner_title
     @owner_title ||= (Etc.getpwnam(owner).gecos || owner)
   end

--- a/app/apps/usr_router.rb
+++ b/app/apps/usr_router.rb
@@ -18,6 +18,10 @@ class UsrRouter
     @owner_title ||= (Etc.getpwnam(owner).gecos || owner)
   end
 
+  def self.all_apps(owners: owners)
+    Array(owners).map { |o| UsrRouter.apps(owner: o) }.flatten
+  end
+
   def self.apps(owner: OodSupport::Process.user.name, require_manifest: true)
     target = base_path(owner: owner)
     if target.directory? && target.executable? && target.readable?

--- a/app/apps/usr_router.rb
+++ b/app/apps/usr_router.rb
@@ -6,6 +6,11 @@ class UsrRouter
     @owner = owner
   end
 
+  # Get a human readable explanation of the owner of this app such as:
+  #
+  #     "Shared by Eric Franz (efranz)"
+  #
+  # @return [String] human readable owner string
   def caption
     "Shared by #{owner_title} (#{owner})"
   end
@@ -18,10 +23,19 @@ class UsrRouter
     @owner_title ||= (Etc.getpwnam(owner).gecos || owner)
   end
 
+  # Get array of all apps from specified owners
+  #
+  # @param owners [String, Array<String>] owner or owners to get apps for
+  # @return [Array<OodApp>] array of apps that the specified owner(s) have
   def self.all_apps(owners: owners)
     Array(owners).map { |o| UsrRouter.apps(owner: o) }.flatten
   end
 
+  # Get array of apps for specified owner
+  #
+  # @param owner [String] username of user to get apps for
+  # @param require_manifest [Boolean] if true, exclude apps that don't have a valid manifest
+  # @return [Array<OodApp] all valid apps owner has shared that user has access to
   def self.apps(owner: OodSupport::Process.user.name, require_manifest: true)
     target = base_path(owner: owner)
     if target.directory? && target.executable? && target.readable?

--- a/app/apps/usr_router.rb
+++ b/app/apps/usr_router.rb
@@ -6,6 +6,14 @@ class UsrRouter
     @owner = owner
   end
 
+  def caption
+    "Shared by #{owner_title} (#{owner})"
+  end
+
+  def owner_title
+    @owner_title ||= (Etc.getpwnam(owner).gecos || owner)
+  end
+
   def self.apps(owner: OodSupport::Process.user.name, require_manifest: true)
     target = base_path(owner: owner)
     if target.directory? && target.executable? && target.readable?

--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -19,8 +19,7 @@ class AppsController < ApplicationController
           g.title = "Your Dev Apps"
         }
       elsif @type == "usr"
-        @groups += OodAppGroup.usr_groups(@owner || UsrRouter.owners)
-        @groups = @groups.map(&:split).flatten.sort_by { |g| g.title  }
+        @groups += OodAppGroup.groups_for(apps: UsrRouter.all_apps(owners: @owner || UsrRouter.owners))
       elsif @type == "sys"
         @groups << OodAppGroup.new.tap { |g|
           g.apps += SysRouter.apps(require_manifest: false)

--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -20,6 +20,7 @@ class AppsController < ApplicationController
         }
       elsif @type == "usr"
         @groups += OodAppGroup.usr_groups(@owner || UsrRouter.owners)
+        @groups = @groups.map(&:split).flatten.sort_by { |g| g.title  }
       elsif @type == "sys"
         @groups << OodAppGroup.new.tap { |g|
           g.apps += SysRouter.apps(require_manifest: false)

--- a/app/views/apps/_app.html.erb
+++ b/app/views/apps/_app.html.erb
@@ -3,5 +3,8 @@
     <%= image_tag app_icon_path(app.name, app.type, app.owner), size: '100x100' %>
   </td>
   <td><%= link_to app.title, app_path(app.name, app.type, app.owner) %></td>
-  <td><%= manifest_markdown(app.manifest.description) %></td>
+  <td>
+    <%= content_tag(:p, content_tag(:strong, app.caption)) if app.caption %>
+    <%= manifest_markdown(app.manifest.description) %>
+  </td>
 </tr>

--- a/app/views/apps/_group.html.erb
+++ b/app/views/apps/_group.html.erb
@@ -1,4 +1,4 @@
-<h2 class="apps-section-header-blue"><%= group.title %> <%= "(#{group.subtitle})" if group.subtitle %></h2>
+<h2 class="apps-section-header-blue"><%= group.title %></h2>
 
 <table class="table">
   <thead>

--- a/test/controllers/products_controller_test.rb
+++ b/test/controllers/products_controller_test.rb
@@ -1,49 +1,4 @@
 require 'test_helper'
 
 class ProductsControllerTest < ActionController::TestCase
-  setup do
-    @product = products(:one)
-  end
-
-  test "should get index" do
-    get :index
-    assert_response :success
-    assert_not_nil assigns(:products)
-  end
-
-  test "should get new" do
-    get :new
-    assert_response :success
-  end
-
-  test "should create product" do
-    assert_difference('Product.count') do
-      post :create, product: {  }
-    end
-
-    assert_redirected_to product_path(assigns(:product))
-  end
-
-  test "should show product" do
-    get :show, id: @product
-    assert_response :success
-  end
-
-  test "should get edit" do
-    get :edit, id: @product
-    assert_response :success
-  end
-
-  test "should update product" do
-    patch :update, id: @product, product: {  }
-    assert_redirected_to product_path(assigns(:product))
-  end
-
-  test "should destroy product" do
-    assert_difference('Product.count', -1) do
-      delete :destroy, id: @product
-    end
-
-    assert_redirected_to products_path
-  end
 end

--- a/test/models/app_router_test.rb
+++ b/test/models/app_router_test.rb
@@ -5,12 +5,12 @@ class AppRouterTest < ActiveSupport::TestCase
   test "DevRouter.apps" do
     dir = Pathname.new(File.realpath(Dir.mktmpdir))
     DevRouter.stubs(:base_path).returns(dir)
-    %w(a b c d.git).each {|d| dir.join(d).mkdir }
+    %w(a b c .git).each {|d| dir.join(d).mkdir }
     FileUtils.touch dir.join("d.txt").to_s
     dir.join("c").chmod(0600)
     dir.join("d.txt").chmod(0700)
 
-    assert_equal ["a", "b"].sort, DevRouter.apps.map(&:name).sort
+    assert_equal ["a", "b"].sort, DevRouter.apps(require_manifest: false).map(&:name).sort
 
     dir.rmtree()
   end

--- a/test/models/ood_app_group_test.rb
+++ b/test/models/ood_app_group_test.rb
@@ -1,32 +1,4 @@
 require 'test_helper'
 
 class OodAppGroupTest < ActiveSupport::TestCase
-
-  test "app groups split by group's specified by apps" do
-    g = OodAppGroup.new
-    g.title = "Default"
-    g.subtitle = "efranz"
-
-    # add apps
-    2.times { g.apps << OpenStruct.new(group: nil) }
-    3.times { g.apps << OpenStruct.new(group: "") }
-    g.apps << OpenStruct.new(group: "Company A")
-    3.times { g.apps << OpenStruct.new(group: "Company B") }
-    4.times { g.apps << OpenStruct.new(group: "Company C") }
-
-    groups = g.split
-    groups = groups.sort_by { |g| g.title }
-
-    # now we should have groups with these titles in this order
-    # [Company A, "Company B", Company C, Default]
-
-    assert_equal 4, groups.count, 'apps with nil and "" groups should be grouped together '
-    assert_equal "Company A", groups.first.title
-    assert_equal "efranz", groups.first.subtitle
-    assert_equal 1, groups.first.apps.count
-
-    assert_equal "Default", groups.last.title
-    assert_equal "efranz", groups.last.subtitle
-    assert_equal 5, groups.last.apps.count
-  end
 end

--- a/test/models/ood_app_group_test.rb
+++ b/test/models/ood_app_group_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+class OodAppGroupTest < ActiveSupport::TestCase
+
+  test "app groups split by group's specified by apps" do
+    g = OodAppGroup.new
+    g.title = "Default"
+    g.subtitle = "efranz"
+
+    # add apps
+    2.times { g.apps << OpenStruct.new(group: nil) }
+    3.times { g.apps << OpenStruct.new(group: "") }
+    g.apps << OpenStruct.new(group: "Company A")
+    3.times { g.apps << OpenStruct.new(group: "Company B") }
+    4.times { g.apps << OpenStruct.new(group: "Company C") }
+
+    groups = g.split
+    groups = groups.sort_by { |g| g.title }
+
+    # now we should have groups with these titles in this order
+    # [Company A, "Company B", Company C, Default]
+
+    assert_equal 4, groups.count, 'apps with nil and "" groups should be grouped together '
+    assert_equal "Company A", groups.first.title
+    assert_equal "efranz", groups.first.subtitle
+    assert_equal 1, groups.first.apps.count
+
+    assert_equal "Default", groups.last.title
+    assert_equal "efranz", groups.last.subtitle
+    assert_equal 5, groups.last.apps.count
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/AweSim-OSC/osc-ondemand/issues/138 and https://github.com/AweSim-OSC/osc-ondemand/issues/137

Manifest lets you specify `group`.
Dashboard uses this to group apps by title.

4 questions:

1. should we restrict which app owners can take advantage of this feature?
2. with this approach, if a wiag shared app we deploy doesn't specify group, the default title will be Basil Gohar - is this bad? should we do this differently i.e. a dot file under ~/awesim/share to specify the default group title to use instead of the geocos - if none is specified
3. in parens, instead of just displaying the username, maybe we should include the geocos too IF the title is replaced by a custom title
4. `group` is ugly because it can be confused with a user group - but this is an "app group". Is there something better?
