### PR TITLE
Extend app sharing

### DIFF
--- a/.env
+++ b/.env
@@ -4,6 +4,10 @@
 # OOD_DASHBOARD_LOGO="https://www.osc.edu/sites/osc.edu/themes/contrib/osc/logo.png"
 OOD_DASHBOARD_LOGO="/public/logo.png"
 
+# SSH host provided by HPC Center for web developers to work on
+# NB: Defaults to the shell apps default host (most likely a login node for a cluster)
+OOD_DEV_SSH_HOST="default"
+
 # for example, add a .env.local with branding for MSI:
 # example branding for Minnesota Supercomputing Institute
 # OOD_DASHBOARD_TITLE="MSI OnDemand"

--- a/.env.local.awesim
+++ b/.env.local.awesim
@@ -1,6 +1,7 @@
 OOD_DASHBOARD_TITLE="AweSim Dashboard"
 OOD_DASHBOARD_HEADER_IMG_LOGO="/public/logo.png"
 OOD_PORTAL="awesim"
+OOD_DEV_SSH_HOST="apps-test.awesim.org"
 
 OOD_APP_SHARING=true
 OOD_NAVBAR_TYPE=default

--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ gem 'browser', '~> 2.2'
 gem 'addressable', '~> 2.4'
 gem 'bootstrap_form', '~> 2.4'
 gem 'jquery-datatables-rails', '~> 3.4'
+gem 'data-confirm-modal', '~> 1.2'
 gem 'rails_12factor', group: :production
 gem 'mocha', '~> 1.1', group: :test
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,8 @@ GEM
       execjs
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.2)
+    data-confirm-modal (1.2.0)
+      railties (>= 3.0)
     dotenv (2.1.1)
     dotenv-rails (2.1.1)
       dotenv (= 2.1.1)
@@ -181,6 +183,7 @@ DEPENDENCIES
   browser (~> 2.2)
   byebug
   coffee-rails (~> 4.1.0)
+  data-confirm-modal (~> 1.2)
   dotenv-rails (~> 2.0)
   font-awesome-sass (~> 4.6)
   jbuilder (~> 2.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,6 +15,7 @@
 //= require bootstrap-sprockets
 //= require dataTables/jquery.dataTables
 //= require dataTables/bootstrap/3/jquery.dataTables.bootstrap
+//= require data-confirm-modal
 //= require_tree .
 
 //FIXME: move to coffescript

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -74,7 +74,7 @@ class ProductsController < ApplicationController
 
     @product.destroy
     respond_to do |format|
-      format.html { redirect_to products_url(type: @type), notice: 'Product was successfully destroyed.' }
+      format.html { redirect_to products_url(type: @type), notice: 'Product was successfully moved to the trash.' }
       format.json { head :no_content }
     end
   end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -139,8 +139,8 @@ class Product
   end
 
   def destroy
-    trash_path.mkpath
-    FileUtils.mv router.path, trash_path.join("#{Time.now.localtime.strftime('%Y%m%dT%H%M%S')}_#{name}")
+    self.class.trash_path.mkpath
+    FileUtils.mv router.path, self.class.trash_path.join("#{Time.now.localtime.strftime('%Y%m%dT%H%M%S')}_#{name}")
   end
 
   def permissions?

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -81,6 +81,14 @@ class Product
     rescue Errno::EACCES
       false
     end
+
+    def trash_path
+      router.base_path.join(".trash")
+    end
+
+    def trash_contents
+      trash_path.directory? ? trash_path.children : []
+    end
   end
 
   def app
@@ -131,7 +139,6 @@ class Product
   end
 
   def destroy
-    trash_path = self.class.router.base_path.join(".trash")
     trash_path.mkpath
     FileUtils.mv router.path, trash_path.join("#{Time.now.localtime.strftime('%Y%m%dT%H%M%S')}_#{name}")
   end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -131,8 +131,9 @@ class Product
   end
 
   def destroy
-    `kill -9 $(lsof -t #{router.path}) && sleep 1`
-    FileUtils.rm_rf(router.path)
+    trash_path = self.class.router.base_path.join(".trash")
+    trash_path.mkpath
+    FileUtils.mv router.path, trash_path.join("#{Time.now.localtime.strftime('%Y%m%dT%H%M%S')}_#{name}")
   end
 
   def permissions?

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -156,9 +156,8 @@ class Product
     permissions(:group)
   end
 
-  def running_users
-    out = `ps -o uid= -p $(pgrep -f '^Passenger .*#{Regexp.quote(router.path.realdirpath.to_s)}') 2> /dev/null | sort | uniq`
-    out.split.map(&:to_i).map do |id|
+  def active_users
+    @active_users ||= `ps -o uid= -p $(pgrep -f '^Passenger .*#{Regexp.quote(router.path.realdirpath.to_s)}') 2> /dev/null | sort | uniq`.split.map(&:to_i).map do |id|
       OodSupport::User.new id
     end
   end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -155,6 +155,13 @@ class Product
     permissions(:group)
   end
 
+  def running_users
+    out = `ps -o uid= -p $(pgrep -f '^Passenger .*#{Regexp.quote(router.path.realdirpath.to_s)}') 2> /dev/null | sort | uniq`
+    out.split.map(&:to_i).map do |id|
+      OodSupport::User.new id
+    end
+  end
+
   private
     def stage
       target = router.path

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -20,7 +20,7 @@
   </td>
   <td data-order="<%= modified_time.to_i %>"><%= modified_time.strftime("%m/%d/%y") %></td>
   <td>
-    <%= link_to 'Shell', OodAppkit.shell.url(host: ENV['OOD_DEV_SSH_HOST'] || 'default', path: product.router.path).to_s, target: '_blank', class: 'btn btn-default btn-block' %>
+    <%= link_to 'Shell', OodAppkit.shell.url(host: ENV['OOD_DEV_SSH_HOST'], path: product.router.path).to_s, target: '_blank', class: 'btn btn-default btn-block' %>
     <%= link_to 'Files', OodAppkit.files.url(path: product.router.path).to_s, target: '_blank', class: 'btn btn-default btn-block' %>
   </td>
   <td>

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -35,7 +35,7 @@
         original_title: 'Are you ABSOLUTELY sure?',
         confirm: '<div class="alert alert-warning">Unexpected bad things will happen if you don\'t read this!</div><p>This will move the product to the trash. Any users currently running this app will experience breaking behavior. Any past or present users of this app will be unable to access their data for this app. Be sure you know what you are doing!</p>'.html_safe,
         verify: product.name,
-        verify_text: 'Please type in the name of the app to confirm.',
+        verify_text: 'Please type in the directory name of the app to confirm.',
         commit: 'I understand the consequences, delete this app',
         commit_class: 'btn-danger btn-block',
         cancel_class: 'hide'

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -27,5 +27,5 @@
     <%= link_to 'Details', product_path(product.name, type: @type), class: 'btn btn-info btn-block' %>
     <%= link_to 'Edit', edit_product_path(product.name, type: @type), class: 'btn btn-default btn-block' %>
   </td>
-  <td><%= link_to 'Delete', product_path(product.name, type: @type), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger pull-right' %></td>
+  <td><%= link_to 'Delete', product_path(product.name, type: @type), method: :delete, data: { confirm: 'This will move the product to the trash. Any data users may have from this app will become inaccessible after this. Be sure you know what you are doing!' }, class: 'btn btn-danger pull-right' %></td>
 </tr>

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -27,5 +27,20 @@
     <%= link_to 'Details', product_path(product.name, type: @type), class: 'btn btn-info btn-block' %>
     <%= link_to 'Edit', edit_product_path(product.name, type: @type), class: 'btn btn-default btn-block' %>
   </td>
-  <td><%= link_to 'Delete', product_path(product.name, type: @type), method: :delete, data: { confirm: 'This will move the product to the trash. Any data users may have from this app will become inaccessible after this. Be sure you know what you are doing!' }, class: 'btn btn-danger pull-right' %></td>
+  <td>
+    <%= link_to 'Delete',
+      product_path(product.name, type: @type),
+      method: :delete,
+      data: {
+        original_title: 'Are you ABSOLUTELY sure?',
+        confirm: '<div class="alert alert-warning">Unexpected bad things will happen if you don\'t read this!</div><p>This will move the product to the trash. Any users currently running this app will experience breaking behavior. Any past or present users of this app will be unable to access their data for this app. Be sure you know what you are doing!</p>'.html_safe,
+        verify: product.name,
+        verify_text: 'Please type in the name of the app to confirm.',
+        commit: 'I understand the consequences, delete this app',
+        commit_class: 'btn-danger btn-block',
+        cancel_class: 'hide'
+      },
+      class: 'btn btn-danger pull-right'
+    %>
+  </td>
 </tr>

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -20,7 +20,7 @@
   </td>
   <td data-order="<%= modified_time.to_i %>"><%= modified_time.strftime("%m/%d/%y") %></td>
   <td>
-    <%= link_to 'Shell', OodAppkit.shell.url(path: product.router.path).to_s, target: '_blank', class: 'btn btn-default btn-block' %>
+    <%= link_to 'Shell', OodAppkit.shell.url(host: ENV['OOD_DEV_SSH_HOST'] || 'default', path: product.router.path).to_s, target: '_blank', class: 'btn btn-default btn-block' %>
     <%= link_to 'Files', OodAppkit.files.url(path: product.router.path).to_s, target: '_blank', class: 'btn btn-default btn-block' %>
   </td>
   <td>

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -6,6 +6,9 @@
   <td><%= product.name %></td>
   <td>
     <%= link_to product.title, app_path(product.app.name, product.app.type, product.app.owner) %>
+    <% unless product.active_users.empty? %>
+      <span class="label label-default pull-right"><%= pluralize product.active_users.size, "active user" %></span>
+    <% end %>
     <p>
       <%= manifest_markdown(product.description) %>
     </p>

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -27,20 +27,4 @@
     <%= link_to 'Details', product_path(product.name, type: @type), class: 'btn btn-info btn-block' %>
     <%= link_to 'Edit', edit_product_path(product.name, type: @type), class: 'btn btn-default btn-block' %>
   </td>
-  <td>
-    <%= link_to 'Delete',
-      product_path(product.name, type: @type),
-      method: :delete,
-      data: {
-        original_title: 'Are you ABSOLUTELY sure?',
-        confirm: '<div class="alert alert-warning">Unexpected bad things will happen if you don\'t read this!</div><p>This will move the product to the trash. Any users currently running this app will experience breaking behavior. Any past or present users of this app will be unable to access their data for this app. Be sure you know what you are doing!</p>'.html_safe,
-        verify: product.name,
-        verify_text: 'Please type in the directory name of the app to confirm.',
-        commit: 'I understand the consequences, delete this app',
-        commit_class: 'btn-danger btn-block',
-        cancel_class: 'hide'
-      },
-      class: 'btn btn-danger pull-right'
-    %>
-  </td>
 </tr>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -1,3 +1,5 @@
+<% product_class = Product.product_types[@type] %>
+
 <h2 class="apps-section-header">
   <%= products_title(@type) %>
 </h2>
@@ -5,8 +7,15 @@
 <p>
   <%= link_to 'New Product', new_product_path(type: @type), class: 'btn btn-default' %>
   <span class="pull-right">
-    <%= link_to 'Launch Shell', OodAppkit.shell.url(path: @type == :dev ? DevRouter.base_path : UsrRouter.base_path.realpath).to_s, target: '_blank', class: 'btn btn-default' %>
-    <%= link_to 'Launch Files', OodAppkit.files.url(path: @type == :dev ? DevRouter.base_path : UsrRouter.base_path.realpath).to_s, target: '_blank', class: 'btn btn-default' %>
+    <%= link_to 'Launch Shell', OodAppkit.shell.url(path: product_class.router.base_path.realpath).to_s, target: '_blank', class: 'btn btn-default' %>
+    <%= link_to 'Launch Files', OodAppkit.files.url(path: product_class.router.base_path.realpath).to_s, target: '_blank', class: 'btn btn-default' %>
+    <% unless product_class.trash_contents.empty? %>
+      <%= link_to "Open Trash <span class=\"badge\">#{product_class.trash_contents.size}</span>".html_safe,
+          OodAppkit.files.url(path: product_class.trash_path.realpath).to_s,
+          target: '_blank',
+          class: 'btn btn-default'
+      %>
+    <% end %>
   </span>
 </p>
 

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -7,7 +7,7 @@
 <p>
   <%= link_to 'New Product', new_product_path(type: @type), class: 'btn btn-default' %>
   <span class="pull-right">
-    <%= link_to 'Launch Shell', OodAppkit.shell.url(host: ENV['OOD_DEV_SSH_HOST'] || 'default', path: product_class.router.base_path.realpath).to_s, target: '_blank', class: 'btn btn-default' %>
+    <%= link_to 'Launch Shell', OodAppkit.shell.url(host: ENV['OOD_DEV_SSH_HOST'], path: product_class.router.base_path.realpath).to_s, target: '_blank', class: 'btn btn-default' %>
     <%= link_to 'Launch Files', OodAppkit.files.url(path: product_class.router.base_path.realpath).to_s, target: '_blank', class: 'btn btn-default' %>
     <% unless product_class.trash_contents.empty? %>
       <%= link_to "Open Trash <span class=\"badge\">#{product_class.trash_contents.size}</span>".html_safe,

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -7,7 +7,7 @@
 <p>
   <%= link_to 'New Product', new_product_path(type: @type), class: 'btn btn-default' %>
   <span class="pull-right">
-    <%= link_to 'Launch Shell', OodAppkit.shell.url(path: product_class.router.base_path.realpath).to_s, target: '_blank', class: 'btn btn-default' %>
+    <%= link_to 'Launch Shell', OodAppkit.shell.url(host: ENV['OOD_DEV_SSH_HOST'] || 'default', path: product_class.router.base_path.realpath).to_s, target: '_blank', class: 'btn btn-default' %>
     <%= link_to 'Launch Files', OodAppkit.files.url(path: product_class.router.base_path.realpath).to_s, target: '_blank', class: 'btn btn-default' %>
     <% unless product_class.trash_contents.empty? %>
       <%= link_to "Open Trash <span class=\"badge\">#{product_class.trash_contents.size}</span>".html_safe,

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -30,7 +30,6 @@
       <th>Last Modified</th>
       <th data-orderable="false" data-searchable="false"></th>
       <th data-orderable="false" data-searchable="false"></th>
-      <th data-orderable="false" data-searchable="false"></th>
     </tr>
   </thead>
 

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -126,7 +126,20 @@
 
 <%= link_to 'Edit', edit_product_path(@product.name, type: @type), class: 'btn btn-default' %>
 <%= link_to 'Back', products_path(type: @type), class: 'btn btn-default' %>
-<%= link_to 'Delete App', product_path(@product.name, type: @type), method: :delete, data: { confirm: 'This will move the product to the trash. Any data users may have from this app will become inaccessible after this. Be sure you know what you are doing!' }, class: 'btn btn-danger pull-right' %>
+<%= link_to 'Delete App',
+  product_path(@product.name, type: @type),
+  method: :delete,
+  data: {
+    original_title: 'Are you ABSOLUTELY sure?',
+    confirm: '<div class="alert alert-warning">Unexpected bad things will happen if you don\'t read this!</div><p>This will move the product to the trash. Any users currently running this app will experience breaking behavior. Any past or present users of this app will be unable to access their data for this app. Be sure you know what you are doing!</p>'.html_safe,
+    verify: @product.name,
+    verify_text: 'Please type in the name of the app to confirm.',
+    commit: 'I understand the consequences, delete this app',
+    commit_class: 'btn-danger btn-block',
+    cancel_class: 'hide'
+  },
+  class: 'btn btn-danger pull-right'
+%>
 
 <div class="modal fade" id="productCliModal" tabindex="-1" role="dialog" data-backdrop="static" data-keyboard="false">
   <div class="modal-dialog modal-lg" role="document">

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -126,7 +126,7 @@
 
 <%= link_to 'Edit', edit_product_path(@product.name, type: @type), class: 'btn btn-default' %>
 <%= link_to 'Back', products_path(type: @type), class: 'btn btn-default' %>
-<%= link_to 'Delete App', product_path(@product.name, type: @type), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger pull-right' %>
+<%= link_to 'Delete App', product_path(@product.name, type: @type), method: :delete, data: { confirm: 'This will move the product to the trash. Any data users may have from this app will become inaccessible after this. Be sure you know what you are doing!' }, class: 'btn btn-danger pull-right' %>
 
 <div class="modal fade" id="productCliModal" tabindex="-1" role="dialog" data-backdrop="static" data-keyboard="false">
   <div class="modal-dialog modal-lg" role="document">

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -19,8 +19,10 @@
       <%= link_to @product.app.title, app_path(@product.app.name, @product.app.type, @product.app.owner), target: '_blank'%>
     </p>
     <p>
-      <strong>Active users:</strong>
-      <%= @product.running_users.size %>
+      <span data-toggle="popover" data-trigger="hover" data-placement="bottom" title="Active Users" data-content="<%= @product.active_users.join("<br />") %>" data-html="true">
+        <strong>Active users:</strong>
+        <%= @product.active_users.size %>
+      </span>
     </p>
     <p>
       <strong>Directory:</strong>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -19,6 +19,10 @@
       <%= link_to @product.app.title, app_path(@product.app.name, @product.app.type, @product.app.owner), target: '_blank'%>
     </p>
     <p>
+      <strong>Active users:</strong>
+      <%= @product.running_users.size %>
+    </p>
+    <p>
       <strong>Directory:</strong>
       <%= @product.router.path.realpath %>
     </p>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -133,7 +133,7 @@
     original_title: 'Are you ABSOLUTELY sure?',
     confirm: '<div class="alert alert-warning">Unexpected bad things will happen if you don\'t read this!</div><p>This will move the product to the trash. Any users currently running this app will experience breaking behavior. Any past or present users of this app will be unable to access their data for this app. Be sure you know what you are doing!</p>'.html_safe,
     verify: @product.name,
-    verify_text: 'Please type in the name of the app to confirm.',
+    verify_text: 'Please type in the directory name of the app to confirm.',
     commit: 'I understand the consequences, delete this app',
     commit_class: 'btn-danger btn-block',
     cancel_class: 'hide'

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -38,7 +38,7 @@
     </p>
   </div><!-- /.col-md-6 -->
   <div class="col-md-2 col-xs-6">
-    <%= link_to 'Shell', OodAppkit.shell.url(host: ENV['OOD_DEV_SSH_HOST'] || 'default', path: @product.router.path).to_s, target: '_blank', class: 'btn btn-default btn-block' %>
+    <%= link_to 'Shell', OodAppkit.shell.url(host: ENV['OOD_DEV_SSH_HOST'], path: @product.router.path).to_s, target: '_blank', class: 'btn btn-default btn-block' %>
     <%= link_to 'Files', OodAppkit.files.url(path: @product.router.path).to_s, target: '_blank', class: 'btn btn-default btn-block' %>
   </div><!-- /.col-md-2 -->
   <div class="col-md-2 col-xs-6">

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -38,7 +38,7 @@
     </p>
   </div><!-- /.col-md-6 -->
   <div class="col-md-2 col-xs-6">
-    <%= link_to 'Shell', OodAppkit.shell.url(path: @product.router.path).to_s, target: '_blank', class: 'btn btn-default btn-block' %>
+    <%= link_to 'Shell', OodAppkit.shell.url(host: ENV['OOD_DEV_SSH_HOST'] || 'default', path: @product.router.path).to_s, target: '_blank', class: 'btn btn-default btn-block' %>
     <%= link_to 'Files', OodAppkit.files.url(path: @product.router.path).to_s, target: '_blank', class: 'btn btn-default btn-block' %>
   </div><!-- /.col-md-2 -->
   <div class="col-md-2 col-xs-6">


### PR DESCRIPTION
Extended with a few more features & fixes:

  - instead of deleting app which leads to issues we just move the app to `.trash` with a timestamp (this fixes those nasty `.nfs*` files being left behind)
  - maybe add an "empty my trash" feature?
  - now we can get a list of active users running the app currently!!!1!1!
  - more to come...