### PR TITLE
show 'no messages available' when the motd file does not exist

### DIFF
--- a/app/views/dashboard/_motd.html.erb
+++ b/app/views/dashboard/_motd.html.erb
@@ -1,18 +1,29 @@
 <h3>Message of the Day</h3>
 
-<% if motd.messages.each do |m| %>
+<% if motd.exist? %>
 
-  <hr>
-  <div class="motd">
-    <h4 class="motd_title"><%= m.date %> - <%= m.title %></h4>
-    <div class="motd_body"><p><%=raw markdown( m.body ) %></p></div>
-  </div>
+  <% if motd.messages.each do |m| %>
 
-<% end.empty? %>
+    <hr>
+    <div class="motd">
+      <h4 class="motd_title"><%= m.date %> - <%= m.title %></h4>
+      <div class="motd_body"><p><%=raw markdown( m.body ) %></p></div>
+    </div>
 
-  <hr>
-  <div class="motd">
-    <h4 class="motd_title">There are no new messages.</h4>
-  </div>
+  <% end.empty? %>
+
+    <hr>
+    <div class="motd">
+      <h4 class="motd_title">There are no new messages.</h4>
+    </div>
+
+  <% end %>
+
+<% else %>
+
+    <hr>
+    <div class="motd">
+      <h4 class="motd_title">No messages available.</h4>
+    </div>
 
 <% end %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -3,7 +3,7 @@
 <p class="lead">OnDemand provides an integrated, single access point for all of your HPC resources.</p>
 <br>
 
-<%= render partial: "motd", locals: { motd: @motd_file  } if @motd_file.exist? %>
+<%= render partial: "motd", locals: { motd: @motd_file  } %>
 
 <!--
 TODO: add getting started


### PR DESCRIPTION
submitted in response to https://github.com/OSC/ood-dashboard/issues/19#issuecomment-257889404

I used the text suggested, but perhaps it could be generalized to avoid duplication with the text for a situation where there are no messages. Alternatively, the message and logic could be updated to more explicitly mention that a motd was not found.

TBH though, I don't know if this is an improvement over the existing behavior, where if the motd is missing it just doesn't show anything. Not sure.

![screen shot 2016-11-02 at 3 51 28 pm](https://cloud.githubusercontent.com/assets/2374718/19944957/4ff4fd16-a114-11e6-998a-f71d22da77a7.png)
