### PR TITLE
fix bug where empty motd file causes exception

### DIFF
--- a/app/models/motd_file.rb
+++ b/app/models/motd_file.rb
@@ -47,10 +47,15 @@ class MotdFile
 
     # get array of sections which are delimited by a row of ******
     sections = f.split(/^\*+$/).map(&:strip).select { |x| ! x.empty?  }
+    raise ArgumentError if sections.empty?
     sections.map! { |s| MotdFile::Message.from(s) }.compact!.sort_by! {|s| s.date }.reverse!
   rescue Errno::ENOENT
     # The messages file does not exist on the system.
-    logger.warn "MOTD File is missing; it was expected at #{motd_system_file}"
+    Rails.logger.warn "MOTD File is missing; it was expected at #{motd_system_file}"
+    []
+  rescue ArgumentError
+    # The messages file exists on the system but it empty or improperly formatted.
+    Rails.logger.warn "MOTD File is empty or incorrectly formatted; update it at #{motd_system_file}"
     []
   end
 

--- a/app/models/motd_file.rb
+++ b/app/models/motd_file.rb
@@ -47,7 +47,7 @@ class MotdFile
 
     # get array of sections which are delimited by a row of ******
     sections = f.split(/^\*+$/).map(&:strip).select { |x| ! x.empty?  }
-    sections.map! { |s| MotdFile::Message.from(s) }.compact.sort_by {|s| s.date }.reverse
+    sections.map { |s| MotdFile::Message.from(s) }.compact.sort_by {|s| s.date }.reverse
   rescue Errno::ENOENT
     # The messages file does not exist on the system.
     Rails.logger.warn "MOTD File is missing; it was expected at #{motd_system_file}"

--- a/app/models/motd_file.rb
+++ b/app/models/motd_file.rb
@@ -47,15 +47,10 @@ class MotdFile
 
     # get array of sections which are delimited by a row of ******
     sections = f.split(/^\*+$/).map(&:strip).select { |x| ! x.empty?  }
-    raise ArgumentError if sections.empty?
-    sections.map! { |s| MotdFile::Message.from(s) }.compact!.sort_by! {|s| s.date }.reverse!
+    sections.map! { |s| MotdFile::Message.from(s) }.compact.sort_by! {|s| s.date }.reverse!
   rescue Errno::ENOENT
     # The messages file does not exist on the system.
     Rails.logger.warn "MOTD File is missing; it was expected at #{motd_system_file}"
-    []
-  rescue ArgumentError
-    # The messages file exists on the system but it empty or improperly formatted.
-    Rails.logger.warn "MOTD File is empty or incorrectly formatted; update it at #{motd_system_file}"
     []
   end
 

--- a/app/models/motd_file.rb
+++ b/app/models/motd_file.rb
@@ -47,7 +47,7 @@ class MotdFile
 
     # get array of sections which are delimited by a row of ******
     sections = f.split(/^\*+$/).map(&:strip).select { |x| ! x.empty?  }
-    sections.map! { |s| MotdFile::Message.from(s) }.compact.sort_by! {|s| s.date }.reverse!
+    sections.map! { |s| MotdFile::Message.from(s) }.compact.sort_by {|s| s.date }.reverse
   rescue Errno::ENOENT
     # The messages file does not exist on the system.
     Rails.logger.warn "MOTD File is missing; it was expected at #{motd_system_file}"

--- a/test/fixtures/files/motd_invalid
+++ b/test/fixtures/files/motd_invalid
@@ -1,0 +1,40 @@
+------------------------------------------------------------------------
+Welcome to the Ohio Supercomputer Center!
+PLEASE SEE THE OSC SUPERCOMPUTING DOCUMENTATION
+FOR ANNOUNCEMENTS/NOTICES AND USER INFORMATION:
+http://www.osc.edu/supercomputing
+For questions or assistance, contact oschelp@osc.edu
+To check for currently known issues, please visit
+https://www.osc.edu/supercomputing/known-issues or follow @HPCNotices
+on Twitter.
+------------------------------------------------------------------------
+Sept. 30 2016
+--- UPDATE ON GPFS SOFTWARE ISSUES
+We are experiencing periodic hangs of the GPFS client file system software
+used with the new storage environment. We have an open support case with
+the vendor, but no solution at this time. This may affect access to the
+/fs/project, and /fs/scratch file systems. Reports of transfer failures
+to these file systems through scp.osc.edu, and sftp.osc.edu
+have been reported.  If you experience any issues with these file systems,
+please contact us at oschelp@osc.edu.
+------------------------------------------------------------------------
+10-21-2016
+--- OUR NEWEST CLUSTER, OWENS, IS NOW OPEN TO ALL USERS
+
+The Owens cluster is now available to all users. It is currently at partial
+capacity as we continue to upgrade the data center. We anticipate the
+cluster will be fully available by early November.
+
+For information on getting started using Owens, please see
+https://www.osc.edu/supercomputing/computing/owens
+------------------------------------------------------------------------
+2016/10/26
+--- OWENS ONLY DOWNTIME FRIDAY, OCTOBER 28 - SUNDAY, OCTOBER 30
+
+On Friday, October 28, a downtime is scheduled for Owens in order
+to benchmark the system. This downtime will only affect the Owens
+cluster. The Oakley and Ruby clusters, web portals and HPC file
+servers will be available.
+
+More details: http://bit.ly/2ev5RfA
+------------------------------------------------------------------------

--- a/test/fixtures/files/motd_valid
+++ b/test/fixtures/files/motd_valid
@@ -1,0 +1,40 @@
+************************************************************************
+Welcome to the Ohio Supercomputer Center!
+PLEASE SEE THE OSC SUPERCOMPUTING DOCUMENTATION
+FOR ANNOUNCEMENTS/NOTICES AND USER INFORMATION:
+http://www.osc.edu/supercomputing
+For questions or assistance, contact oschelp@osc.edu
+To check for currently known issues, please visit
+https://www.osc.edu/supercomputing/known-issues or follow @HPCNotices
+on Twitter.
+************************************************************************
+2016/09/30
+--- UPDATE ON GPFS SOFTWARE ISSUES
+We are experiencing periodic hangs of the GPFS client file system software
+used with the new storage environment. We have an open support case with
+the vendor, but no solution at this time. This may affect access to the
+/fs/project, and /fs/scratch file systems. Reports of transfer failures
+to these file systems through scp.osc.edu, and sftp.osc.edu
+have been reported.  If you experience any issues with these file systems,
+please contact us at oschelp@osc.edu.
+************************************************************************
+2016/10/21
+--- OUR NEWEST CLUSTER, OWENS, IS NOW OPEN TO ALL USERS
+
+The Owens cluster is now available to all users. It is currently at partial
+capacity as we continue to upgrade the data center. We anticipate the
+cluster will be fully available by early November.
+
+For information on getting started using Owens, please see
+https://www.osc.edu/supercomputing/computing/owens
+************************************************************************
+2016/10/26
+--- OWENS ONLY DOWNTIME FRIDAY, OCTOBER 28 - SUNDAY, OCTOBER 30
+
+On Friday, October 28, a downtime is scheduled for Owens in order
+to benchmark the system. This downtime will only affect the Owens
+cluster. The Oakley and Ruby clusters, web portals and HPC file
+servers will be available.
+
+More details: http://bit.ly/2ev5RfA
+************************************************************************

--- a/test/models/motd_test.rb
+++ b/test/models/motd_test.rb
@@ -20,4 +20,40 @@ class MotdTest < ActiveSupport::TestCase
     assert_equal nil, MotdFile::Message.from(msg)
   end
 
+  test "test when motd valid" do
+    path = "#{Rails.root}/test/fixtures/files/motd_valid"
+    motd_file = MotdFile.new(path)
+
+    assert_equal true, motd_file.exist?
+    assert_equal path, motd_file.motd_system_file
+    assert_equal 3, motd_file.messages.count
+  end
+
+  test "test when motd invalid" do
+    path = "#{Rails.root}/test/fixtures/files/motd_invalid"
+    motd_file = MotdFile.new(path)
+
+    assert_equal true, motd_file.exist?
+    assert_equal path, motd_file.motd_system_file
+    assert_equal 0, motd_file.messages.count
+  end
+
+  test "test when motd empty" do
+    path = "#{Rails.root}/test/fixtures/files/motd_empty"
+    motd_file = MotdFile.new(path)
+
+    assert_equal true, motd_file.exist?
+    assert_equal path, motd_file.motd_system_file
+    assert_equal 0, motd_file.messages.count
+  end
+
+  test "test when motd missing" do
+    path = "#{Rails.root}/test/fixtures/files/motd_missing"
+    motd_file = MotdFile.new(path)
+
+    assert_equal false, motd_file.exist?
+    assert_equal path, motd_file.motd_system_file
+    assert_equal 0, motd_file.messages.count
+  end
+
 end


### PR DESCRIPTION
Fixes https://github.com/OSC/ood-dashboard/issues/19

Throw and catch an ArgumentError when the motd parser can't get any sections.

I feel like more things can go wrong with that regex in the wild though, and we may want to consider another rescue block that catches any other types of exceptions from that block and moves on.