### PR TITLE
[DO NOT MERGE] move nav Help dd config to initializer

### DIFF
--- a/app/apps/nav_config.rb
+++ b/app/apps/nav_config.rb
@@ -1,6 +1,10 @@
 class NavConfig
   class << self
-    attr_accessor :categories
+    attr_accessor :categories, :help_dropdown_links, :user_dropdown_links
   end
   self.categories = ["Files", "Jobs", "Clusters", "Desktops"]
+
+  # array of NavLink objects
+  self.help_dropdown_links = []
+  self.user_dropdown_links = []
 end

--- a/app/apps/nav_link.rb
+++ b/app/apps/nav_link.rb
@@ -1,0 +1,11 @@
+class NavLink
+  # icon - font awesome icon
+  attr_accessor :icon, :text, :url, :separator
+
+  def initialize(icon: "gear",text:,url:,separator: false)
+    @separator = separator
+    @icon = icon
+    @text = text
+    @url = url
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,15 +11,6 @@ module ApplicationHelper
     "/nginx/stop?redir=#{root_path}"
   end
 
-
-  def support_url
-    ENV['OOD_DASHBOARD_SUPPORT_URL'] || "#"
-  end
-
-  def docs_url
-    ENV['OOD_DASHBOARD_DOCS_URL'] || "#"
-  end
-
   def passwd_url
     ENV['OOD_DASHBOARD_PASSWD_URL'] || "#"
   end

--- a/app/views/layouts/nav/_help_dropdown.html.erb
+++ b/app/views/layouts/nav/_help_dropdown.html.erb
@@ -1,6 +1,7 @@
+<% if NavConfig.help_dropdown_links.any? %>
 <li class="dropdown"> <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help<span class="caret"></span></a>
 <ul class="dropdown-menu">
-  <li><a href="<%= support_url %>"><i class="fa fa-question-circle"></i> Contact Support</a></li>
-  <li><a href="<%= docs_url %>"><i class="fa fa-info-circle"></i> Online Documentation</a></li>
+  <%= render partial: 'layouts/nav/link', collection: NavConfig.help_dropdown_links, as: 'link' %>
 </ul>
 </li>
+<% end %>

--- a/app/views/layouts/nav/_link.html.erb
+++ b/app/views/layouts/nav/_link.html.erb
@@ -1,0 +1,1 @@
+<li><a href="<%= link.url %>"><i class="fa fa-<%= link.icon %>"></i> <%= link.text %></a>

--- a/config/initializers/ood.rb.osc
+++ b/config/initializers/ood.rb.osc
@@ -1,6 +1,11 @@
 # OSC
 NavConfig.categories << "Desktop Apps"
 
+NavConfig.help_dropdown_links.tap do |dd|
+  dd << NavLink.new(icon: 'question-circle', text: 'Contact Support', url: "https://www.osc.edu/contact/supercomputing_support")
+  dd << NavLink.new(icon: 'info-circle', text: 'Online Documentation', url: )
+end
+
 OodFilesApp.candidate_favorite_paths.tap do |paths|
   # add project space directories
   projects = User.new.groups.map(&:name).grep(/^P./)


### PR DESCRIPTION
This is an example of moving the navbar Help dropdown configuration
to the initializer. Instead of specifying a fixed number of URLs that can be specified,
let the installer specify any number of links.

I actually don't like this: asking the sys admin to write code like this:

```ruby
NavConfig.help_dropdown_links << NavLink.new(icon: 'question-circle', text: 'Contact Support', url: "https://www.osc.edu/contact/supercomputing_support")
```

However, we could actually maintain the status quo with the ENV vars and still go this route by simply adding another initializer `ood_nav_urls.rb` and do something like this:

```ruby
NavConfig.help_dropdown_links << NavLink.new(icon: 'question-circle', text: 'Contact Support', url: ENV['OOD_DASHBOARD_SUPPORT_URL']) if ENV['OOD_DASHBOARD_SUPPORT_URL']
```