### PR TITLE
hide help and user dropdown links if not set

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,17 +11,20 @@ module ApplicationHelper
     "/nginx/stop?redir=#{root_path}"
   end
 
+  def nav_link(title, icon, url)
+    %Q(<li><a href="#{url}"><i class="fa fa-#{icon}"></i> #{title}</a></li>).html_safe if url
+  end
 
   def support_url
-    ENV['OOD_DASHBOARD_SUPPORT_URL'] || "#"
+    ENV['OOD_DASHBOARD_SUPPORT_URL']
   end
 
   def docs_url
-    ENV['OOD_DASHBOARD_DOCS_URL'] || "#"
+    ENV['OOD_DASHBOARD_DOCS_URL']
   end
 
   def passwd_url
-    ENV['OOD_DASHBOARD_PASSWD_URL'] || "#"
+    ENV['OOD_DASHBOARD_PASSWD_URL']
   end
 
   def app_icon_tag(app)

--- a/app/views/layouts/nav/_help_dropdown.html.erb
+++ b/app/views/layouts/nav/_help_dropdown.html.erb
@@ -1,6 +1,8 @@
+<% if support_url || docs_url %>
 <li class="dropdown"> <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help<span class="caret"></span></a>
 <ul class="dropdown-menu">
-  <li><a href="<%= support_url %>"><i class="fa fa-question-circle"></i> Contact Support</a></li>
-  <li><a href="<%= docs_url %>"><i class="fa fa-info-circle"></i> Online Documentation</a></li>
+  <%= nav_link("Contact Support", "question-circle", support_url) %>
+  <%= nav_link("Online Documenetation", "info-circle", docs_url) %>
 </ul>
 </li>
+<% end %>

--- a/app/views/layouts/nav/_user_dropdown.html.erb
+++ b/app/views/layouts/nav/_user_dropdown.html.erb
@@ -1,16 +1,18 @@
+<% if @logout_url || passwd_url %>
+
 <li class="dropdown">
   <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button"
     aria-haspopup="true" aria-expanded="false">
     <i class="fa fa-user"></i><span class="hidden-xs hidden-sm"> Logged in as <%= @user.name %></span><span class="caret"></span>
   </a>
   <ul class="dropdown-menu">
-    <li><a href="<%= passwd_url %>"><i class="fa fa-gear"></i> Change HPC Password</a>
-    </li>
-
-    <% if @logout_url %>
-    <li role="separator" class="divider"></li>
-    <li><a href="<%= @logout_url %>"><i class="fa fa-power-off"></i> Logout</a>
-    </li>
-    <% end %>
+    <%= nav_link("Change HPC Password", "gear", passwd_url) %>
+    <%= nav_link("Logout", "power-off", @logout_url) %>
   </ul>
 </li>
+
+<% else %>
+  <p class="navbar-text">
+    <i class="fa fa-user"></i><span class="hidden-xs hidden-sm"> Logged in as <%= @user.name %></span>
+  </p>
+<% end %>


### PR DESCRIPTION
Fixes https://github.com/OSC/ood-dashboard/issues/71

- hide links if not set
- if no links in help dropdown, remove dropdown
- if no links in user dropdown, show text instead of dropdown for logged in user

this is a much simpler implementation than doing something more complex like in https://github.com/OSC/ood-dashboard/pull/76, which requires more thought