### PR TITLE
show shell link even if no cluster config avail

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,7 +12,7 @@ module ApplicationHelper
   end
 
   def nav_link(title, icon, url, target: "_self")
-    %Q(<li><a href="#{url}" target="#{target}"><i class="fa fa-#{icon}"></i> #{title}</a></li>).html_safe if url
+    render partial: "layouts/nav/link", locals: { title: title, faicon: icon, url: url.to_s, target: target  } if url
   end
 
   def support_url

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,8 +11,8 @@ module ApplicationHelper
     "/nginx/stop?redir=#{root_path}"
   end
 
-  def nav_link(title, icon, url)
-    %Q(<li><a href="#{url}"><i class="fa fa-#{icon}"></i> #{title}</a></li>).html_safe if url
+  def nav_link(title, icon, url, target: "_self")
+    %Q(<li><a href="#{url}" target="#{target}"><i class="fa fa-#{icon}"></i> #{title}</a></li>).html_safe if url
   end
 
   def support_url

--- a/app/views/layouts/nav/_group.html.erb
+++ b/app/views/layouts/nav/_group.html.erb
@@ -19,7 +19,7 @@
           <%= nav_link("Shell Access", "terminal", OodAppkit.shell.url, target: "_blank") if login_clusters.count == 0 %>
 
           <% login_clusters.each do |c| %>
-            <%= nav_link "#{c.title} Shell Access", "terminal", OodAppkit.shell.url(host: c.login_server.host) %>
+            <%= nav_link "#{c.title} Shell Access", "terminal", OodAppkit.shell.url(host: c.login_server.host), target: "_blank" %>
           <% end %>
 
         <% else %>

--- a/app/views/layouts/nav/_group.html.erb
+++ b/app/views/layouts/nav/_group.html.erb
@@ -16,6 +16,8 @@
           <% end %>
 
         <% elsif app.role == "shell" %>
+          <%= nav_link("Shell Access", "terminal", OodAppkit.shell.url, target: "_blank") if login_clusters.count == 0 %>
+
           <% login_clusters.each do |c| %>
             <li><a href="<%= OodAppkit.shell.url(host: c.login_server.host) %>" target="_blank"><i class="fa fa-terminal"></i> <%= c.title %> Shell Access</a></li>
           <% end %>

--- a/app/views/layouts/nav/_group.html.erb
+++ b/app/views/layouts/nav/_group.html.erb
@@ -19,7 +19,7 @@
           <%= nav_link("Shell Access", "terminal", OodAppkit.shell.url, target: "_blank") if login_clusters.count == 0 %>
 
           <% login_clusters.each do |c| %>
-            <li><a href="<%= OodAppkit.shell.url(host: c.login_server.host) %>" target="_blank"><i class="fa fa-terminal"></i> <%= c.title %> Shell Access</a></li>
+            <%= nav_link "#{c.title} Shell Access", "terminal", OodAppkit.shell.url(host: c.login_server.host) %>
           <% end %>
 
         <% else %>

--- a/app/views/layouts/nav/_link.html.erb
+++ b/app/views/layouts/nav/_link.html.erb
@@ -1,3 +1,11 @@
+<%#
+locals:
+title - required - text for the link
+url - required - link url string
+faicon - optional, default "gear" - font awesome icon to use
+target - optional, default "_self" - link target
+%>
+
 <li>
   <%= link_to url, target: local_assigns.fetch(:target, "_self") do %>
     <i class="fa fa-<%= local_assigns.fetch(:faicon, "gear") %>"></i> <%= title %>

--- a/app/views/layouts/nav/_link.html.erb
+++ b/app/views/layouts/nav/_link.html.erb
@@ -1,0 +1,5 @@
+<li>
+  <%= link_to url, target: local_assigns.fetch(:target, "_self") do %>
+    <i class="fa fa-<%= local_assigns.fetch(:faicon, "gear") %>"></i> <%= title %>
+  <% end %>
+</li>


### PR DESCRIPTION
Fixes #80 

If the login_servers array is empty, display a link to "Shell Access"
requesting to open the default host for the shell app

This way, a default install of OOD will allow the Shell link to appear
in the nav bar without a cluster config, which is overkill if you are giving
access to only one host.