### PR TITLE
Version badges

### DIFF
--- a/app/apps/ood_app.rb
+++ b/app/apps/ood_app.rb
@@ -82,7 +82,6 @@ class OodApp
     repo = git_remote_origin_url.scan(/((git|ssh|http(s)?)|(git@[\w\.]+))(:(\/\/)?)([\w\.@\:\/\-~]+)(\.git)(\/)?/)
     # ex. https://badge.fury.io/gh/osc%2Food-fileeditor.svg
     "https://badge.fury.io/gh/#{repo[0][6].gsub("/", "%2F")}.svg"
-    #repo[0][6]
   end
 
   # Get the owner, group, and octal access rights via stat on the app directory

--- a/app/apps/ood_app.rb
+++ b/app/apps/ood_app.rb
@@ -77,6 +77,14 @@ class OodApp
     `cd #{path} 2> /dev/null && HOME="" git config --get remote.origin.url 2> /dev/null`.strip
   end
 
+  def badge_url
+    # Borrowed from https://www.debuggex.com/r/H4kRw1G0YPyBFjfm
+    repo = git_remote_origin_url.scan(/((git|ssh|http(s)?)|(git@[\w\.]+))(:(\/\/)?)([\w\.@\:\/\-~]+)(\.git)(\/)?/)
+    # ex. https://badge.fury.io/gh/osc%2Food-fileeditor.svg
+    "https://badge.fury.io/gh/#{repo[0][6].gsub("/", "%2F")}.svg"
+    #repo[0][6]
+  end
+
   # Get the owner, group, and octal access rights via stat on the app directory
   #
   # @return [Hash] with user, group, and permissions

--- a/app/views/version_lists/show.html.erb
+++ b/app/views/version_lists/show.html.erb
@@ -17,7 +17,8 @@
         <dl class="dl-horizontal">
           <dt>Remote:</dt><dd><%= app.git_remote_origin_url %></dd>
           <dt>Sha:</dt><dd><%= app.git_sha %></dd>
-          <dt>Version:</dt><dd><%= app.git_version %></dd>
+          <dt>Installed Version:</dt><dd><%= app.git_version %></dd>
+          <dt>Current Version:</dt><dd><img src="<%= app.badge_url %>"></dd>
           <dt>User:</dt><dd><%= app.stat[:user] %></dd>
           <dt>Group:</dt><dd><%= app.stat[:group] %></dd>
           <dt>Access Rights:</dt><dd><%= app.stat[:permissions] %></dd>


### PR DESCRIPTION
An update that adds version badges of the latest release to the output page.

* Note: This requires the origins to be both public and set to the correct location. (i.e. not github redirects)

We've renamed and publicized many of our repositories. We would need to update `git remote origin` to the correct path for this to work, otherwise it will display "Version ?.?.?"

This may not be appropriate in all situations, for example, when semver is not appropriately employed, or if a repo is private, but that would be on the developer.

![versions](https://cloud.githubusercontent.com/assets/2374718/20686787/072892ea-b588-11e6-9194-13b4a50568cc.png)
