### PR TITLE
in manifest, add ability to specify app url

### DIFF
--- a/app/apps/dev_router.rb
+++ b/app/apps/dev_router.rb
@@ -40,4 +40,8 @@ class DevRouter
   def path
     @path ||= base_path.join(name)
   end
+
+  def token
+    "#{type}/#{name}"
+  end
 end

--- a/app/apps/dev_router.rb
+++ b/app/apps/dev_router.rb
@@ -2,7 +2,7 @@ class DevRouter
   attr_reader :name, :owner, :caption, :category
 
   def initialize(name, owner=OodSupport::Process.user.name)
-    @name = name
+    @name = name.to_s
     @owner = owner
     @caption = "Sandbox App"
     @category = "Sandbox Apps"

--- a/app/apps/manifest.rb
+++ b/app/apps/manifest.rb
@@ -1,7 +1,7 @@
 require 'yaml'
 
 class Manifest
-  attr_reader :name, :description, :category, :subcategory, :icon, :role
+  attr_reader :name, :description, :category, :subcategory, :icon, :role, :url
 
   class InvalidContentError < StandardError
     def initialize
@@ -50,7 +50,7 @@ category: OSC
   end
 
   def defaults
-    {"name" => "", "description" => "", "category" => "", "subcategory" => "" , "icon" => "", "role" => ""}
+    {"name" => "", "description" => "", "category" => "", "subcategory" => "" , "icon" => "", "role" => "", "url" => ""}
   end
 
   def initialize(opts)
@@ -65,6 +65,7 @@ category: OSC
     @subcategory = opts.fetch("subcategory")
     @icon = opts.fetch("icon")
     @role = opts.fetch("role")
+    @url = opts.fetch("url")
   end
 
   def valid?

--- a/app/apps/ood_app.rb
+++ b/app/apps/ood_app.rb
@@ -1,6 +1,6 @@
 class OodApp
   attr_reader :router
-  delegate :owner, :caption, :url, :type, :path, to: :router
+  delegate :owner, :caption, :type, :path, :name, :token, to: :router
 
   PROTECTED_NAMES = ["shared_apps", "cgi-bin", "tmp"]
 
@@ -19,12 +19,21 @@ class OodApp
     @router = router
   end
 
-  def name
-    path.basename.to_s
-  end
-
   def title
     manifest.name.empty? ? name.titleize : manifest.name
+  end
+
+  def url
+    if manifest.url.empty?
+      router.url
+    else
+      manifest.url % {
+        app_type: type,
+        app_owner: owner,
+        app_name: name,
+        app_token: token
+      }
+    end
   end
 
   def has_gemfile?

--- a/app/apps/path_router.rb
+++ b/app/apps/path_router.rb
@@ -1,7 +1,7 @@
 # A special router to use to instantiate an OodApp
 # object if all you have is the path to the app
 class PathRouter
-  attr_reader :category, :caption, :url, :type, :path
+  attr_reader :category, :caption, :url, :type, :path, :name, :token
 
   def initialize(path)
     @caption = nil
@@ -9,6 +9,8 @@ class PathRouter
     @url = "#"
     @type = :path
     @path = Pathname.new(path)
+    @name = @path.basename.to_s
+    @token = @name
   end
 
   def owner

--- a/app/apps/sys_router.rb
+++ b/app/apps/sys_router.rb
@@ -28,6 +28,10 @@ class SysRouter
     @name = name
   end
 
+  def token
+    "#{type}/#{name}"
+  end
+
   def self.base_path
     Pathname.new "/var/www/ood/apps/sys"
   end

--- a/app/apps/sys_router.rb
+++ b/app/apps/sys_router.rb
@@ -25,7 +25,7 @@ class SysRouter
   end
 
   def initialize(name)
-    @name = name
+    @name = name.to_s
   end
 
   def token

--- a/app/apps/usr_router.rb
+++ b/app/apps/usr_router.rb
@@ -2,7 +2,7 @@ class UsrRouter
   attr_reader :name, :owner
 
   def initialize(name, owner=OodSupport::Process.user.name)
-    @name = name
+    @name = name.to_s
     @owner = owner
   end
 

--- a/app/apps/usr_router.rb
+++ b/app/apps/usr_router.rb
@@ -91,4 +91,8 @@ class UsrRouter
   def type
     :usr
   end
+
+  def token
+    "#{type}/#{owner}/#{name}"
+  end
 end


### PR DESCRIPTION
this is the final end point that the user is redirected to when launching
the app from the dashboard

this can be a c-style template string with named variables like: %{app_type}

* app_type
* app_name
* app_owner
* app_token

So we can have vncsim style apps where a single vncsim app is deployed at

    url: /pun/sys/vncsim

and multiple "apps" which are just directories with manifests and vncsim job templates
can be deployed. Thus, a job template for launching abaqus apps is deployed to

    path: /var/www/ood/apps/sys/abaqus

but when you access this app from the dashboard you sent to

    url: /pun/sys/vncsim/sys/sys/abaqus

and vncsim is properly setup to scope the routes so it knows which template to use