### PR TITLE
add error message when git commit fails

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -246,7 +246,8 @@ class Product
     def clone_git_repo(target)
       o, s = Open3.capture2e({"HOME" => ""}, "git", "clone", git_remote, target.to_s)
       unless s.success?
-        errors.add(:git_remote, "was unable to be cloned")
+        errors.add(:git_remote, "was unable to be cloned:")
+        errors.add(:git_remote_error, o)
         Rails.logger.error(o)
         return false
       end

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -7,6 +7,9 @@
   <% if show_git && (@product.new_record? || @product.git_repo?) %>
   <div class="field">
     <%= f.text_field :git_remote, help: "Example: <strong>git@github.com:Example/example.git</strong> (<a href='https://help.github.com/articles/generating-an-ssh-key/' target='_blank'>requires SSH key installed</a>)".html_safe %>
+    <% if @product.errors[:git_remote_error].any? %>
+        <pre class="text-danger"><%= @product.errors[:git_remote_error].first.html_safe %></pre>
+    <% end %>
   </div>
   <div class="alert alert-<%= ssh_key ? "success" : "danger" %> clearfix alert-ssh-key">
   <% if ssh_key %>

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -7,9 +7,7 @@
   <% if show_git && (@product.new_record? || @product.git_repo?) %>
   <div class="field">
     <%= f.text_field :git_remote, help: "Example: <strong>git@github.com:Example/example.git</strong> (<a href='https://help.github.com/articles/generating-an-ssh-key/' target='_blank'>requires SSH key installed</a>)".html_safe %>
-    <% if @product.errors[:git_remote_error].any? %>
-        <pre class="text-danger"><%= @product.errors[:git_remote_error].first.html_safe %></pre>
-    <% end %>
+    <%= content_tag :pre, @product.errors[:git_remote_error].first.html_safe, class: "text-danger" if @product.errors[:git_remote_error].any? %>
   </div>
   <div class="alert alert-<%= ssh_key ? "success" : "danger" %> clearfix alert-ssh-key">
   <% if ssh_key %>


### PR DESCRIPTION
Mostly Fixes #86 

The only issue is that the Open3 command doesn't maintain the command, so I only show the stdout and stderr here. If we want to add the shell command string I'll need to basically build one out of the Open3 commands at https://github.com/OSC/ood-dashboard/compare/cloneerror?expand=1#diff-7425083b688c32187c716cc5c53c664fR247

If you want me to go ahead with that let me know. Here's where we're at now:

![cloneerror](https://cloud.githubusercontent.com/assets/2374718/21321010/06f4b060-c5e1-11e6-9c1e-b649aa8e09ed.png)
