### PR TITLE
add dashboard site-wide announcement

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  before_filter :set_user, :set_logout_url, :set_nav_groups
+  before_filter :set_user, :set_logout_url, :set_nav_groups, :set_announcement
 
   def set_user
     @user = User.new
@@ -20,5 +20,12 @@ class ApplicationController < ActionController::Base
   def set_nav_groups
     #TODO: for AweSim, what if we added the shared apps here?
     @nav_groups = OodAppGroup.select(titles: NavConfig.categories, groups: OodAppGroup.groups_for(apps: SysRouter.apps))
+  end
+
+  def set_announcement
+    path = Pathname.new(ENV["OOD_ANNOUNCEMENT_PATH"] || "/etc/ood/config/announcement.md")
+    @announcement = path.read if path.file?
+  rescue => e
+    logger.warn "Failed to read announcement file at: #{path} with error: #{e.message}"
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -68,6 +68,12 @@
       </div>
     <% end %>
 
+    <% if @announcement %>
+      <div class="alert alert-warning" role="alert">
+        <%=raw markdown(@announcement) %>
+      </div>
+    <% end %>
+
     <%= yield %>
 
   </div><!-- /.container -->


### PR DESCRIPTION
Addresses https://github.com/OSC/ood_appkit/issues/32 but just for the dashboard.

Create a file at `/etc/ood/config/announcement.md` and the contents will be displayed as a site-wide message to everybody.

This is a candidate for a feature that could be useful on a per-app basis as well.