### PR TITLE
add spacing below row. fixes #132

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -51,6 +51,12 @@ body {
   padding-top: $navbar-height + 10;
 }
 
+// Borrowed from bootstrap 4
+// Remove this block if/when upgraded to bootstrap 4
+.mb-2 {
+  margin-bottom: (2rem * .25) !important;
+}
+
 // Your custom css styles below (must be manually added)
 @import "dashboard";
 @import "navbar";

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -9,7 +9,7 @@
 
 <h3>Details</h3>
 
-<div class="row">
+<div class="row mb-2">
   <div class="col-md-2 col-sm-2 col-xs-12">
     <p>
       <%= app_icon_tag(@product.app) %>


### PR DESCRIPTION
I borrowed the new spacing classes from bootstrap 4 for this:
https://v4-alpha.getbootstrap.com/utilities/spacing/

If/when this is ever updated to Bootstrap 4 the custom style can be removed and it will work the same way.