### PR TITLE
Prepare 1.10.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This app is a Rails app for Open OnDemand that serves as a gateway to launching 
   ```sh
   scl enable git19 -- git clone https://github.com/OSC/ood-dashboard.git dashboard
   cd dashboard
-  scl enable git19 -- git checkout tags/v1.9.0
+  scl enable git19 -- git checkout tags/v1.10.0
   ```
 
 2. Build the app (install dependencies and build assets)
@@ -43,7 +43,7 @@ When updating a deployed version of the Open OnDemand dashboard.
   ```sh
   cd dashboard # cd to build directory
   scl enable git19 -- git fetch
-  scl enable git19 -- git checkout tags/v1.9.0 # check out latest tag
+  scl enable git19 -- git checkout tags/v1.10.0 # check out latest tag
   ```
 
 2. Install gem dependencies and rebuild assets


### PR DESCRIPTION
See this for the full file diff:

https://github.com/OSC/ood-dashboard/compare/v1.9.0...release_1.10.0

Release notes should be (markdown):

```markdown

### Changed

- **All apps launch in a new browser window**
- site specific configs changed: OSC AweSim dashboard matches OSC OnDemand dashboard
- App Sharing: OOD_APP_CATALOG_URL for AweSim is now being used again
- App Sharing: shared app links now display using a launchpad style buttons instead of a table

### Fixed

- clean up code that shows home link only if develop dropdown displays
- remove some control flow from the views and controller code when creating new "products" for app development
- .env is no longer required for installation as defaults are now set in app.js for file upload max, and editor and shell URIs
```