### PR TITLE
Motd options

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -56,8 +56,15 @@ body {
   margin-bottom: (1rem * .50) !important;
 }
 
+pre.motd_monospaced {
+  background-color: #FFFFFF;
+  border: none;
+}
+
 // Your custom css styles below (must be manually added)
 @import "dashboard";
 @import "navbar";
 @import "apps";
 @import "products";
+
+

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -57,7 +57,7 @@ body {
 }
 
 // Remove the well-styling from the bootstrap <pre>
-pre.motd_monospaced {
+pre.motd-monospaced {
   background-color: #FFFFFF;
   border: none;
 }

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -59,6 +59,7 @@ body {
 // Remove the well-styling from the bootstrap <pre>
 pre.motd-monospaced {
   background-color: #FFFFFF;
+  font-size: 14px;
   border: none;
 }
 

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -56,6 +56,7 @@ body {
   margin-bottom: (1rem * .50) !important;
 }
 
+// Remove the well-styling from the bootstrap <pre>
 pre.motd_monospaced {
   background-color: #FFFFFF;
   border: none;

--- a/app/models/motd_file.rb
+++ b/app/models/motd_file.rb
@@ -24,14 +24,6 @@ class MotdFile
     @motd_text_format = format
   end
 
-  # An empty file whose modification timestamp indicates the last time the user
-  # viewed the motd messages. This is useful for when we want to use the file
-  # system to determine when new messages the user has not seen have been
-  # added to the motd.
-  def motd_config_file
-    @motd_config_file ||= OodAppkit.dataroot.join(".motd")
-  end
-
   def exist?
     motd_system_file && File.file?(motd_system_file)
   end

--- a/app/models/motd_file.rb
+++ b/app/models/motd_file.rb
@@ -54,6 +54,11 @@ class MotdFile
 
   private
 
+    # Parse the MOTD in OSC style
+    # See: https://github.com/OSC/ood-dashboard/wiki/Message-of-the-Day
+    #
+    # @param [String] content The content to be parsed
+  # @return [String] The text formatted to html
     def parse_osc(content)
       # get array of sections which are delimited by a row of ******
       sections = content.split(/^\*+$/).map(&:strip).select { |x| ! x.empty?  }
@@ -65,7 +70,14 @@ class MotdFile
       )
     end
 
+  # Parse the MOTD in markdown using Redcarpet gem
+  #
+  # @param [String] content The content to be parsed
+  # @return [String] The text formatted to html
     def parse_markdown(content)
+      markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML, autolink: true, tables: true)
+
+      messages = markdown.render(content)
 
       ApplicationController.new.render_to_string(
           :partial => 'dashboard/motd_markdown',
@@ -73,6 +85,10 @@ class MotdFile
       )
     end
 
+  # Parse the MOTD in plain text
+  #
+  # @param [String] content The content to be parsed
+  # @return [String] The text formatted to html
     def parse_text(content)
       messages = content
 

--- a/app/models/motd_file.rb
+++ b/app/models/motd_file.rb
@@ -20,8 +20,6 @@ class MotdFile
   def initialize(path = ENV['MOTD_PATH'], format = ENV['MOTD_FORMAT'], update_user_view_timestamp: false)
     @motd_system_file = path
     @motd_text_format = format
-
-    touch if update_user_view_timestamp
   end
 
   # An empty file whose modification timestamp indicates the last time the user
@@ -36,12 +34,6 @@ class MotdFile
     motd_system_file && File.file?(motd_system_file)
   end
 
-  # If the motd file hasn't been created on the system, or if the system motd is newer than the user's file, return true.
-  def new_messages?
-    # FIXME: Use if/else statements because this is arcane
-    (messages.count > 0) ? ( !File.exist?(motd_config_file) ? true : File.new(motd_system_file).ctime > File.new(motd_config_file).ctime ? true : false ) : false   
-  end
-
   # Create an array of message objects based on the current message of the day.
   def messages
     f = File.read motd_system_file
@@ -54,15 +46,4 @@ class MotdFile
     Rails.logger.warn "MOTD File is missing; it was expected at #{motd_system_file}"
     []
   end
-
-  # The system will use a file called '.motd' to track when the user last was alerted to messages.
-  # This method should be called when the message of the day page is checked so that the dashboard knows when
-  # the user last viewed the page.
-  #
-  # Calling self.touch will create the .motd file, or update the timestamp if it already exists.
-  def touch
-    FileUtils.mkdir_p(File.dirname(motd_config_file)) unless File.exists?(motd_config_file)
-    FileUtils.touch(motd_config_file)
-  end
-    
 end

--- a/app/models/motd_file.rb
+++ b/app/models/motd_file.rb
@@ -1,5 +1,5 @@
 class MotdFile
-  attr_reader :motd_system_file
+  attr_reader :motd_system_file, :motd_text_format
 
   Message = Struct.new :date, :title, :body do
     def self.from(str)
@@ -17,8 +17,9 @@ class MotdFile
   # Initialize the Motd Controller object based on the current user.
   #
   # @param [boolean] update_user_view_timestamp True to update the last viewed timestamp. (Default: false)
-  def initialize(path = ENV['MOTD_PATH'], update_user_view_timestamp: false)
+  def initialize(path = ENV['MOTD_PATH'], format = ENV['MOTD_FORMAT'], update_user_view_timestamp: false)
     @motd_system_file = path
+    @motd_text_format = format
 
     touch if update_user_view_timestamp
   end

--- a/app/models/motd_file.rb
+++ b/app/models/motd_file.rb
@@ -16,6 +16,8 @@ class MotdFile
   end
   # Initialize the Motd Controller object based on the current user.
   #
+  # @param [String] path The path to the motd file on disk
+  # @param [String] format The formatter to use when parsing the motd
   # @param [boolean] update_user_view_timestamp True to update the last viewed timestamp. (Default: false)
   def initialize(path = ENV['MOTD_PATH'], format = ENV['MOTD_FORMAT'], update_user_view_timestamp: false)
     @motd_system_file = path

--- a/app/models/motd_file.rb
+++ b/app/models/motd_file.rb
@@ -62,11 +62,11 @@ class MotdFile
     def parse_osc(content)
       # get array of sections which are delimited by a row of ******
       sections = content.split(/^\*+$/).map(&:strip).select { |x| ! x.empty?  }
-      message = sections.map { |s| MotdFile::Message.from(s) }.compact.sort_by {|s| s.date }.reverse
+      messages = sections.map { |s| MotdFile::Message.from(s) }.compact.sort_by {|s| s.date }.reverse
 
       ApplicationController.new.render_to_string(
           :partial => 'dashboard/motd_osc',
-          :locals => { :message => message }
+          :locals => { :messages => messages }
       )
     end
 

--- a/app/models/motd_file.rb
+++ b/app/models/motd_file.rb
@@ -77,9 +77,7 @@ class MotdFile
   # @param [String] content The content to be parsed
   # @return [String] The text formatted to html
     def parse_markdown(content)
-      markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML, autolink: true, tables: true)
-
-      messages = markdown.render(content)
+      messages = OodAppkit.markdown.render(content)
 
       ApplicationController.new.render_to_string(
           :partial => 'dashboard/motd_markdown',

--- a/app/views/dashboard/_motd.html.erb
+++ b/app/views/dashboard/_motd.html.erb
@@ -1,3 +1,1 @@
-<h3>Message of the Day</h3>
-
 <%= motd.messages %>

--- a/app/views/dashboard/_motd.html.erb
+++ b/app/views/dashboard/_motd.html.erb
@@ -1,18 +1,3 @@
 <h3>Message of the Day</h3>
 
-<% if motd.messages.each do |m| %>
-
-  <hr>
-  <div class="motd">
-    <h4 class="motd_title"><%= m.date %> - <%= m.title %></h4>
-    <div class="motd_body"><p><%=raw markdown( m.body ) %></p></div>
-  </div>
-
-<% end.empty? %>
-
-  <hr>
-  <div class="motd">
-    <h4 class="motd_title">There are no new messages.</h4>
-  </div>
-
-<% end %>
+<%= motd.messages %>

--- a/app/views/dashboard/_motd_markdown.html.erb
+++ b/app/views/dashboard/_motd_markdown.html.erb
@@ -1,0 +1,1 @@
+<div><%= messages.html_safe %></div>

--- a/app/views/dashboard/_motd_osc.html.erb
+++ b/app/views/dashboard/_motd_osc.html.erb
@@ -1,3 +1,5 @@
+<h3>Message of the Day</h3>
+
 <% if messages.each do |m| %>
 
   <hr>

--- a/app/views/dashboard/_motd_osc.html.erb
+++ b/app/views/dashboard/_motd_osc.html.erb
@@ -1,0 +1,16 @@
+<% if messages.each do |m| %>
+
+  <hr>
+  <div class="motd">
+    <h4 class="motd_title"><%= m.date %> - <%= m.title %></h4>
+    <div class="motd_body"><p><%=raw markdown( m.body ) %></p></div>
+  </div>
+
+<% end.empty? %>
+
+  <hr>
+  <div class="motd">
+    <h4 class="motd_title">There are no new messages.</h4>
+  </div>
+
+<% end %>

--- a/app/views/dashboard/_motd_text.html.erb
+++ b/app/views/dashboard/_motd_text.html.erb
@@ -1,1 +1,1 @@
-<pre class="motd_monospaced"><%= messages %></pre>
+<pre class="motd-monospaced"><%= messages %></pre>

--- a/app/views/dashboard/_motd_text.html.erb
+++ b/app/views/dashboard/_motd_text.html.erb
@@ -1,0 +1,1 @@
+<pre class="motd_monospaced"><%= messages %></pre>


### PR DESCRIPTION
Proposed initial solution to satisfy https://github.com/OSC/ood-dashboard/issues/150

#### Note: This PR does not address RSS

For context, a default installation does not include any MOTD display by default:

![no_motd_path](https://cloud.githubusercontent.com/assets/2374718/25761792/110fe0c6-31aa-11e7-9c2d-40bcbf9cc980.png)

*****

To display anything, the admin must first supply `ENV['MOTD_PATH']`

The app now defaults to plain text formatting:

![motd_path_no_motd_format](https://cloud.githubusercontent.com/assets/2374718/25761826/30a341c6-31aa-11e7-95a5-4f1257d0fdb9.png)

*****

To parse the content of the MOTD, the admin can provide `ENV['MOTD_FORMAT']`

There are two options currently, `MOTD_FORMAT='markdown'` and `MOTD_FORMAT='osc'`

### Markdown Style

![motd_path_motd_format_markdown](https://cloud.githubusercontent.com/assets/2374718/25761924/96e2f364-31aa-11e7-9d34-270f9d1dad17.png)

*****

### OSC Style

![motd_path_motd_format_osc](https://cloud.githubusercontent.com/assets/2374718/25761955/b89bffaa-31aa-11e7-833f-0615064e5e3a.png)

*****