### PR TITLE
Show all subapps interactive apps lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Show batch connect "subapps" in navigation instead of just the parent app
+- Default batch connect app titles to name of directory or subapp
+
+### Fixed
+
+- Prevent problems with batch connect app from causing dashboard to crash
+- Properly clean up /tmp after running unit tests
+
+
 ### Added
 
 - Added support for the PBS Pro adapter when using the `bc_num_slots` smart

--- a/app/apps/ood_app.rb
+++ b/app/apps/ood_app.rb
@@ -44,6 +44,10 @@ class OodApp
     role == "batch_connect"
   end
 
+  def batch_connect
+    @batch_connect ||= BatchConnect::App.new(router: router)
+  end
+
   def has_gemfile?
     path.join("Gemfile").file? && path.join("Gemfile.lock").file?
   end

--- a/app/controllers/batch_connect/session_contexts_controller.rb
+++ b/app/controllers/batch_connect/session_contexts_controller.rb
@@ -2,16 +2,9 @@ class BatchConnect::SessionContextsController < ApplicationController
   # GET /batch_connect/<app_token>/session_contexts/new
   def new
     set_app
-    set_sub_apps
     set_render_format
     set_session_context
     set_apps
-
-    # Redirect to first valid sub app otherwise first invalid sub app
-    unless @sub_apps.include? @app
-      sub_app_token = ( @sub_apps.select(&:valid?).first || @sub_apps.first ).token
-      redirect_to new_batch_connect_session_context_url(token: sub_app_token)
-    end
 
     if @app.valid?
       # Read in context from cache file
@@ -31,7 +24,6 @@ class BatchConnect::SessionContextsController < ApplicationController
   # POST /batch_connect/<app_token>/session_contexts.json
   def create
     set_app
-    set_sub_apps
     set_render_format
     set_session_context
     set_apps
@@ -62,11 +54,6 @@ class BatchConnect::SessionContextsController < ApplicationController
     def set_apps
       # get lists of apps
       @apps = sys_app_groups.select(&:has_batch_connect_apps?)
-    end
-
-    # Set the list of sub apps
-    def set_sub_apps
-      @sub_apps = @app.sub_app_list
     end
 
     # Set the session context from the app

--- a/app/controllers/batch_connect/session_contexts_controller.rb
+++ b/app/controllers/batch_connect/session_contexts_controller.rb
@@ -15,9 +15,6 @@ class BatchConnect::SessionContextsController < ApplicationController
         #{@app.validation_reason} Please contact support if you see this message
       EOT
     end
-  rescue BatchConnect::App::AppNotFound => e
-    flash.now[:alert] = e.message
-    @app = nil
   end
 
   # POST /batch_connect/<app_token>/session_contexts

--- a/app/controllers/batch_connect/session_contexts_controller.rb
+++ b/app/controllers/batch_connect/session_contexts_controller.rb
@@ -11,9 +11,7 @@ class BatchConnect::SessionContextsController < ApplicationController
       @session_context.from_json(cache_file.read) if cache_file.file?
     else
       @session_context = nil  # do not display session context form
-      flash.now[:alert] = <<-EOT.html_safe
-        #{@app.validation_reason} Please contact support if you see this message
-      EOT
+      flash.now[:alert] = @app.validation_reason
     end
   end
 

--- a/app/models/batch_connect/app.rb
+++ b/app/models/batch_connect/app.rb
@@ -99,9 +99,7 @@ module BatchConnect
     # Whether this is a valid app the user can use
     # @return [Boolean] whether valid app
     def valid?
-      return false if @validation_reason
-
-      cluster && cluster.job_allow?
+      (! form_config.empty?) && cluster && cluster.job_allow?
     end
 
     # The reason why this app may or may not be valid

--- a/app/models/batch_connect/app.rb
+++ b/app/models/batch_connect/app.rb
@@ -99,7 +99,9 @@ module BatchConnect
     # The reason why this app may or may not be valid
     # @return [String] reason why not valid
     def validation_reason
-      if !cluster
+      if !cluster_id
+        "This app does not specify a cluster."
+      elsif !cluster
         "This app requires a cluster that does not exist."
       elsif !cluster.job_allow?
         "You do not have access to use this app."

--- a/app/models/batch_connect/app.rb
+++ b/app/models/batch_connect/app.rb
@@ -93,12 +93,16 @@ module BatchConnect
     # Whether this is a valid app the user can use
     # @return [Boolean] whether valid app
     def valid?
+      return false if @validation_reason
+
       cluster && cluster.job_allow?
     end
 
     # The reason why this app may or may not be valid
     # @return [String] reason why not valid
     def validation_reason
+      return @validation_reason if @validation_reason
+
       if !cluster_id
         "This app does not specify a cluster."
       elsif !cluster
@@ -207,6 +211,12 @@ module BatchConnect
           hsh = hsh.deep_merge read_yaml_erb(path: file, binding: binding)
         end
         @form_config = hsh
+      rescue AppNotFound => e
+        @validation_reason = e.message
+        return {}
+      rescue => e
+        @validation_reason = "#{e.class.name}: #{e.message}"
+        return {}
       end
 
       # Hash describing the full submission properties

--- a/app/models/batch_connect/app.rb
+++ b/app/models/batch_connect/app.rb
@@ -179,7 +179,7 @@ module BatchConnect
 
     private
       def build_sub_app_list
-        return [self] unless sub_app_root.directory?
+        return [self] unless sub_app_root.directory? && sub_app_root.readable? && sub_app_root.executable?
         list = sub_app_root.children.select(&:file?).map do |f|
           root = f.dirname
           name = f.basename.to_s.split(".").first

--- a/app/models/batch_connect/app.rb
+++ b/app/models/batch_connect/app.rb
@@ -69,7 +69,13 @@ module BatchConnect
     # Title for the batch connect app
     # @return [String] title of app
     def title
-      form_config.fetch(:title, "No title set")
+      form_config.fetch(:title, default_title)
+    end
+
+    # Default title for the batch connect app
+    # @return [String] default title of app
+    def default_title
+      sub_app ? sub_app.titleize : root.basename.to_s.titleize
     end
 
     # Description for the batch connect app

--- a/app/models/batch_connect/app.rb
+++ b/app/models/batch_connect/app.rb
@@ -157,14 +157,7 @@ module BatchConnect
     # (including this app as well)
     # @return [Array<App>] list of sub apps
     def sub_app_list
-      return [self] unless sub_app_root.directory?
-      list = sub_app_root.children.select(&:file?).map do |f|
-        root = f.dirname
-        name = f.basename.to_s.split(".").first
-        file = form_file(root: root, name: name)
-        self.class.new(router: router, sub_app: name) if f == file
-      end.compact
-      list.empty? ? [self] : list.sort_by(&:sub_app)
+      @sub_app_list ||= build_sub_app_list
     end
 
     # Convert object to string
@@ -181,6 +174,17 @@ module BatchConnect
     end
 
     private
+      def build_sub_app_list
+        return [self] unless sub_app_root.directory?
+        list = sub_app_root.children.select(&:file?).map do |f|
+          root = f.dirname
+          name = f.basename.to_s.split(".").first
+          file = form_file(root: root, name: name)
+          self.class.new(router: router, sub_app: name) if f == file
+        end.compact
+        list.empty? ? [self] : list.sort_by(&:sub_app)
+      end
+
       # Path to file describing form hash
       def form_file(root:, name: "form")
         %W(#{name}.yml.erb #{name}.yml).map { |f| root.join(f) }.select(&:file?).first

--- a/app/views/batch_connect/session_contexts/new.html.erb
+++ b/app/views/batch_connect/session_contexts/new.html.erb
@@ -26,24 +26,7 @@
       <%= render partial: 'batch_connect/sessions/app_list', collection: @apps, locals: { current_app_token: @app.base_token } %>
     </div>
 
-    <%# More than one sub app so display tabs %>
-    <% if @sub_apps.size > 1 %>
-      <div class="col-md-3 col-md-push-6">
-        <ul class="nav nav-pills nav-stacked well">
-          <% @sub_apps.each do |sub_app| %>
-            <li class="<%= "active" if @app == sub_app %> <%= "disabled" unless sub_app.valid? %>">
-              <% if sub_app.valid? %>
-                <%= link_to sub_app.title, new_batch_connect_session_context_path(token: sub_app.token) %>
-              <% else %>
-                <a data-toggle="tooltip" data-placement="bottom" title="<%= sub_app.validation_reason %>"><%= sub_app.title %></a>
-              <% end %>
-            </li>
-          <% end %>
-        </ul>
-      </div><!-- /.col-md-3 -->
-    <% end %>
-
-    <div class="col-md-6 <%= "col-md-pull-3" if @sub_apps.size > 1 %>">
+    <div class="col-md-6">
       <div class="ood-appkit markdown">
         <%= OodAppkit.markdown.render(@app.description).html_safe %>
 

--- a/app/views/batch_connect/sessions/_app_list_item.html.erb
+++ b/app/views/batch_connect/sessions/_app_list_item.html.erb
@@ -1,12 +1,14 @@
-<%= link_to app.url,
-  class: "list-group-item #{'active' if current_app_token == app.token}",
-  data: {
-    # toggle: "popover",
-    content: manifest_markdown(app.manifest.description),
-    html: true,
-    # trigger: "hover",
-    title: app.title,
-    container: "body"
-} do %>
-  <%= app_icon_tag(app) %> <%= app.title %>
+<% BatchConnect::App.new(router: app.router).sub_app_list.each do |sub_app| %>
+  <%= link_to new_batch_connect_session_context_path(token: sub_app.token),
+    class: "list-group-item #{'active' if @app && @app == sub_app}",
+    data: {
+      # toggle: "popover",
+      content: manifest_markdown(app.manifest.description),
+      html: true,
+      # trigger: "hover",
+      title: sub_app.title,
+      container: "body"
+  } do %>
+    <%= app_icon_tag(app) %> <%= sub_app.title %>
+  <% end %>
 <% end %>

--- a/app/views/batch_connect/sessions/_app_list_item.html.erb
+++ b/app/views/batch_connect/sessions/_app_list_item.html.erb
@@ -1,4 +1,4 @@
-<% BatchConnect::App.new(router: app.router).sub_app_list.each do |sub_app| %>
+<% app.batch_connect.sub_app_list.each do |sub_app| %>
   <%= link_to new_batch_connect_session_context_path(token: sub_app.token),
     class: "list-group-item #{'active' if @app && @app == sub_app}",
     data: {

--- a/app/views/batch_connect/sessions/_app_list_item.html.erb
+++ b/app/views/batch_connect/sessions/_app_list_item.html.erb
@@ -1,4 +1,4 @@
-<% app.batch_connect.sub_app_list.each do |sub_app| %>
+<% app.batch_connect.sub_app_list.select(&:valid?).each do |sub_app| %>
   <%= link_to new_batch_connect_session_context_path(token: sub_app.token),
     class: "list-group-item #{'active' if @app && @app == sub_app}",
     data: {

--- a/app/views/layouts/nav/_group.html.erb
+++ b/app/views/layouts/nav/_group.html.erb
@@ -31,7 +31,9 @@
 
         <% elsif app.role == "batch_connect" %>
           <%# batch connect apps open in dashboard, so can open in same window %>
-          <li class="<%= app.role %>"><a href="<%= app.url %>"><%= app_icon_tag(app) %> <%= app.title %></a></li>
+          <% BatchConnect::App.new(router: app.router).sub_app_list.each do |sub_app| %>
+            <li class="<%= app.role %>"><a href="<%= new_batch_connect_session_context_path(token: sub_app.token) %>"><%= app_icon_tag(app) %> <%= sub_app.title %></a></li>
+          <% end %>
         <% else %>
           <li class="<%= app.role %>"><a href="<%= app_path(app.name, app.type, app.owner) %>" target="_blank"><%= app_icon_tag(app) %> <%= app.title %></a></li>
         <% end %>

--- a/app/views/layouts/nav/_group.html.erb
+++ b/app/views/layouts/nav/_group.html.erb
@@ -31,7 +31,7 @@
 
         <% elsif app.role == "batch_connect" %>
           <%# batch connect apps open in dashboard, so can open in same window %>
-          <% BatchConnect::App.new(router: app.router).sub_app_list.each do |sub_app| %>
+          <% app.batch_connect.sub_app_list.each do |sub_app| %>
             <li class="<%= app.role %>"><a href="<%= new_batch_connect_session_context_path(token: sub_app.token) %>"><%= app_icon_tag(app) %> <%= sub_app.title %></a></li>
           <% end %>
         <% else %>

--- a/app/views/layouts/nav/_group.html.erb
+++ b/app/views/layouts/nav/_group.html.erb
@@ -31,7 +31,7 @@
 
         <% elsif app.role == "batch_connect" %>
           <%# batch connect apps open in dashboard, so can open in same window %>
-          <% app.batch_connect.sub_app_list.each do |sub_app| %>
+          <% app.batch_connect.sub_app_list.select(&:valid?).each do |sub_app| %>
             <li class="<%= app.role %>"><a href="<%= new_batch_connect_session_context_path(token: sub_app.token) %>"><%= app_icon_tag(app) %> <%= sub_app.title %></a></li>
           <% end %>
         <% else %>

--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -81,14 +81,14 @@ class DashboardControllerTest < ActionController::TestCase
       "Interactive Sessions",
       :divider,
       {header: "Apps"},
-      "Jupyter",
+      "Jupyter Notebook",
       "Paraview",
       :divider,
       {header: "Desktops"},
-      "Desktops"], dditems
+      "Oakley Desktop"], dditems
 
-    assert_select dd, "li a", "Desktops" do |link|
-      assert_equal "/batch_connect/sys/bc_desktop/session_contexts/new", link.first['href'], "Desktops link is incorrect"
+    assert_select dd, "li a", "Oakley Desktop" do |link|
+      assert_equal "/batch_connect/sys/bc_desktop/oakley/session_contexts/new", link.first['href'], "Desktops link is incorrect"
     end
 
     SysRouter.unstub(:base_path)

--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -5,13 +5,11 @@ class DashboardControllerTest < ActionController::TestCase
   def setup
     SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys"))
     OodFilesApp.any_instance.stubs(:favorite_paths).returns([Pathname.new("/fs/scratch/efranz")])
-    OodAppkit.stubs(:clusters).returns([])
   end
 
   def teardown
     SysRouter.unstub(:base_path)
     OodFilesApp.any_instance.unstub(:favorite_paths)
-    OodAppkit.unstub(:clusters)
   end
 
   def dropdown_list(title)
@@ -58,7 +56,13 @@ class DashboardControllerTest < ActionController::TestCase
     dditems = dropdown_list_items(dd)
 
     assert dditems.any?, "dropdown list items not found"
-    assert_equal ["Shell Access", "System Status"], dditems
+
+    #FIXME: reorder so this is alphabetical, then fix code
+    assert_equal [
+      "Ruby Shell Access",
+      "Owens Shell Access",
+      "Oakley Shell Access",
+      "System Status"], dditems
 
     assert_select dd, "li a", "System Status" do |link|
       assert_equal "/apps/show/systemstatus", link.first['href'], "System Status link is incorrect"

--- a/test/fixtures/config/clusters.d/oakley.yml
+++ b/test/fixtures/config/clusters.d/oakley.yml
@@ -1,0 +1,102 @@
+---
+v1:
+  title: "Oakley"
+  url: "https://www.osc.edu/supercomputing/computing/oakley"
+  validators:
+    rsv_query:
+      - type: "OodAppkit::Validators::Groups"
+        data:
+          groups:
+            - "sysp"
+            - "hpcsoft"
+          allow: false
+  cluster:
+    type: "OodCluster::Cluster"
+    data:
+      hpc_cluster: true
+      servers:
+        login:
+          type: "OodCluster::Servers::Ssh"
+          data:
+            host: "oakley.osc.edu"
+        resource_mgr:
+          type: "OodCluster::Servers::Torque"
+          data:
+            host: "oak-batch.osc.edu"
+            lib: "/opt/torque/lib64"
+            bin: "/opt/torque/bin"
+            version: "6.0.1"
+        scheduler:
+          type: "OodCluster::Servers::Moab"
+          data:
+            host: "oak-batch.osc.edu"
+            bin: "/opt/moab/bin"
+            version: "9.0.1"
+            moabhomedir: "/var/spool/moab"
+        ganglia:
+          type: "OodCluster::Servers::Ganglia"
+          data:
+            host: "ganglia.osc.edu"
+            scheme: "https://"
+            segments:
+              - "graph.php"
+            req_query:
+              c: "Oakley"
+            opt_query:
+              h: "%{h}.ten.osc.edu"
+            version: "3"
+
+v2:
+  metadata:
+    title: "Oakley"
+    url: "https://www.osc.edu/supercomputing/computing/oakley"
+    hidden: false
+  login:
+    host: "oakley.osc.edu"
+  job:
+    adapter: "torque"
+    host: "oak-batch.osc.edu"
+    lib: "/opt/torque/lib64"
+    bin: "/opt/torque/bin"
+    version: "6.0.1"
+  custom:
+    pbs:
+      host: "oak-batch.osc.edu"
+      lib: "/opt/torque/lib64"
+      bin: "/opt/torque/bin"
+      version: "6.0.1"
+    moab:
+      host: "oak-batch.osc.edu"
+      bin: "/opt/moab/bin"
+      version: "9.0.1"
+      homedir: "/var/spool/moab"
+    rsv_query:
+      torque_host: "oak-batch.osc.edu"
+      torque_lib: "/opt/torque/lib64"
+      torque_bin: "/opt/torque/bin"
+      torque_version: "6.0.1"
+      moab_host: "oak-batch.osc.edu"
+      moab_bin: "/opt/moab/bin"
+      moab_version: "9.0.1"
+      moab_homedir: "/var/spool/moab"
+      acls:
+        - adapter: "group"
+          groups:
+            - "sysp"
+            - "hpcsoft"
+          type: "blacklist"
+    ganglia:
+      host: "ganglia.osc.edu"
+      scheme: "https://"
+      segments:
+        - "graph.php"
+      req_query:
+        c: "Oakley"
+      opt_query:
+        h: "%{h}.ten.osc.edu"
+      version: "3"
+  batch_connect:
+      basic:
+        script_wrapper: "module restore\n%s"
+      vnc:
+        script_wrapper: "module restore\nmodule load ondemand-vnc\n%s"

--- a/test/fixtures/config/clusters.d/owens.yml
+++ b/test/fixtures/config/clusters.d/owens.yml
@@ -1,0 +1,102 @@
+---
+v1:
+  title: "Owens"
+  url: "https://www.osc.edu/supercomputing/computing/owens"
+  validators:
+    rsv_query:
+      - type: "OodAppkit::Validators::Groups"
+        data:
+          groups:
+            - "sysp"
+            - "hpcsoft"
+          allow: false
+  cluster:
+    type: "OodCluster::Cluster"
+    data:
+      hpc_cluster: true
+      servers:
+        login:
+          type: "OodCluster::Servers::Ssh"
+          data:
+            host: "owens.osc.edu"
+        resource_mgr:
+          type: "OodCluster::Servers::Torque"
+          data:
+            host: "owens-batch.ten.osc.edu"
+            lib: "/opt/torque/lib64"
+            bin: "/opt/torque/bin"
+            version: "6.0.1"
+        scheduler:
+          type: "OodCluster::Servers::Moab"
+          data:
+            host: "owens-batch.ten.osc.edu"
+            bin: "/opt/moab/bin"
+            version: "9.0.1"
+            moabhomedir: "/var/spool/moab"
+        ganglia:
+          type: "OodCluster::Servers::Ganglia"
+          data:
+            host: "ganglia.osc.edu"
+            scheme: "https://"
+            segments:
+              - "graph.php"
+            req_query:
+              c: "Owens"
+            opt_query:
+              h: "%{h}.ten.osc.edu"
+            version: "3"
+
+v2:
+  metadata:
+    title: "Owens"
+    url: "https://www.osc.edu/supercomputing/computing/owens"
+    hidden: false
+  login:
+    host: "owens.osc.edu"
+  job:
+    adapter: "torque"
+    host: "owens-batch.ten.osc.edu"
+    lib: "/opt/torque/lib64"
+    bin: "/opt/torque/bin"
+    version: "6.0.1"
+  custom:
+    pbs:
+      host: "owens-batch.ten.osc.edu"
+      lib: "/opt/torque/lib64"
+      bin: "/opt/torque/bin"
+      version: "6.0.1"
+    moab:
+      host: "owens-batch.ten.osc.edu"
+      bin: "/opt/moab/bin"
+      version: "9.0.1"
+      homedir: "/var/spool/moab"
+    rsv_query:
+      torque_host: "owens-batch.ten.osc.edu"
+      torque_lib: "/opt/torque/lib64"
+      torque_bin: "/opt/torque/bin"
+      torque_version: "6.0.1"
+      moab_host: "owens-batch.ten.osc.edu"
+      moab_bin: "/opt/moab/bin"
+      moab_version: "9.0.1"
+      moab_homedir: "/var/spool/moab"
+      acls:
+        - adapter: "group"
+          groups:
+            - "sysp"
+            - "hpcsoft"
+          type: "blacklist"
+    ganglia:
+      host: "ganglia.osc.edu"
+      scheme: "https://"
+      segments:
+        - "graph.php"
+      req_query:
+        c: "Owens"
+      opt_query:
+        h: "%{h}.ten.osc.edu"
+      version: "3"
+  batch_connect:
+      basic:
+        script_wrapper: "module restore\n%s"
+      vnc:
+        script_wrapper: "module restore\nmodule load ondemand-vnc\n%s"

--- a/test/fixtures/config/clusters.d/quick.yml
+++ b/test/fixtures/config/clusters.d/quick.yml
@@ -1,0 +1,39 @@
+---
+v1:
+  title: "Quick"
+  url: ""
+  cluster:
+    type: "OodCluster::Cluster"
+    data:
+      hpc_cluster: false
+      servers:
+        resource_mgr:
+          type: "OodCluster::Servers::Torque"
+          data:
+            host: "quick-batch.ten.osc.edu"
+            lib: "/opt/torque/lib64"
+            bin: "/opt/torque/bin"
+            version: "6.0.2"
+
+v2:
+  metadata:
+    title: "Quick"
+    url: ""
+    hidden: true
+  job:
+    adapter: "torque"
+    host: "quick-batch.ten.osc.edu"
+    lib: "/opt/torque/lib64"
+    bin: "/opt/torque/bin"
+    version: "6.0.2"
+  custom:
+    pbs:
+      host: "quick-batch.ten.osc.edu"
+      lib: "/opt/torque/lib64"
+      bin: "/opt/torque/bin"
+      version: "6.0.2"
+  batch_connect:
+      basic:
+        script_wrapper: "module restore\n%s"
+      vnc:
+        script_wrapper: "module restore\nmodule load ondemand-vnc\n%s"

--- a/test/fixtures/config/clusters.d/ruby.yml
+++ b/test/fixtures/config/clusters.d/ruby.yml
@@ -1,0 +1,113 @@
+---
+v1:
+  title: "Ruby"
+  url: "https://www.osc.edu/supercomputing/computing/ruby"
+  validators:
+    cluster:
+      - type: "OodAppkit::Validators::Groups"
+        data:
+          groups:
+            - "ruby"
+          allow: true
+    rsv_query:
+      - type: "OodAppkit::Validators::Groups"
+        data:
+          groups:
+            - "sysp"
+            - "hpcsoft"
+          allow: false
+  cluster:
+    type: "OodCluster::Cluster"
+    data:
+      hpc_cluster: true
+      servers:
+        login:
+          type: "OodCluster::Servers::Ssh"
+          data:
+            host: "ruby.osc.edu"
+        resource_mgr:
+          type: "OodCluster::Servers::Torque"
+          data:
+            host: "ruby-batch.ten.osc.edu"
+            lib: "/opt/torque/lib64"
+            bin: "/opt/torque/bin"
+            version: "6.0.1"
+        scheduler:
+          type: "OodCluster::Servers::Moab"
+          data:
+            host: "ruby-batch.ten.osc.edu"
+            bin: "/opt/moab/bin"
+            version: "9.0.1"
+            moabhomedir: "/var/spool/moab"
+        ganglia:
+          type: "OodCluster::Servers::Ganglia"
+          data:
+            host: "ganglia.osc.edu"
+            scheme: "https://"
+            segments:
+              - "graph.php"
+            req_query:
+              c: "Ruby"
+            opt_query:
+              h: "%{h}.ten.osc.edu"
+            version: "3"
+
+v2:
+  metadata:
+    title: "Ruby"
+    url: "https://www.osc.edu/supercomputing/computing/ruby"
+    hidden: false
+  acls:
+    - adapter: "group"
+      groups:
+        - "ruby"
+      type: "whitelist"
+  login:
+    host: "ruby.osc.edu"
+  job:
+    adapter: "torque"
+    host: "ruby-batch.ten.osc.edu"
+    lib: "/opt/torque/lib64"
+    bin: "/opt/torque/bin"
+    version: "6.0.1"
+  custom:
+    pbs:
+      host: "ruby-batch.ten.osc.edu"
+      lib: "/opt/torque/lib64"
+      bin: "/opt/torque/bin"
+      version: "6.0.1"
+    moab:
+      host: "ruby-batch.ten.osc.edu"
+      bin: "/opt/moab/bin"
+      version: "9.0.1"
+      homedir: "/var/spool/moab"
+    rsv_query:
+      torque_host: "ruby-batch.ten.osc.edu"
+      torque_lib: "/opt/torque/lib64"
+      torque_bin: "/opt/torque/bin"
+      torque_version: "6.0.1"
+      moab_host: "ruby-batch.ten.osc.edu"
+      moab_bin: "/opt/moab/bin"
+      moab_version: "9.0.1"
+      moab_homedir: "/var/spool/moab"
+      acls:
+        - adapter: "group"
+          groups:
+            - "sysp"
+            - "hpcsoft"
+          type: "blacklist"
+    ganglia:
+      host: "ganglia.osc.edu"
+      scheme: "https://"
+      segments:
+        - "graph.php"
+      req_query:
+        c: "Ruby"
+      opt_query:
+        h: "%{h}.ten.osc.edu"
+      version: "3"
+  batch_connect:
+      basic:
+        script_wrapper: "module restore\n%s"
+      vnc:
+        script_wrapper: "module restore\nmodule load ondemand-vnc\n%s"

--- a/test/fixtures/sys_with_interactive_apps/bc_desktop/form.yml
+++ b/test/fixtures/sys_with_interactive_apps/bc_desktop/form.yml
@@ -1,0 +1,23 @@
+---
+description: |
+  This app will launch an interactive desktop on one or more compute nodes. You
+  will have full access to the resources these nodes provide. This is analogous
+  to an interctive batch job.
+
+attributes:
+  desktop: "mate"
+  bc_vnc_idle: 0
+  bc_vnc_resolution:
+    required: true
+  node_type: null
+
+form:
+  - bc_vnc_idle
+  - desktop
+  - bc_num_hours
+  - bc_num_slots
+  - node_type
+  - bc_account
+  - bc_queue
+  - bc_vnc_resolution
+  - bc_email_on_started

--- a/test/fixtures/sys_with_interactive_apps/bc_desktop/local/oakley.yml
+++ b/test/fixtures/sys_with_interactive_apps/bc_desktop/local/oakley.yml
@@ -1,0 +1,34 @@
+---
+title: "Oakley Desktop"
+cluster: "oakley"
+attributes:
+  desktop: "gnome"
+  bc_queue: null
+  bc_account:
+    help: "You can leave this blank if **not** in multiple projects."
+  node_type:
+    widget: select
+    label: "Node type"
+    help: |
+      - **any** - (*12 cores*) Chooses anyone of the available Oakley nodes.
+        This reduces the wait time as you have no requirements.
+      - **vis** - (*12 cores*) This node includes an NVIDIA Tesla M2070 GPU
+        with an X server running in the background. This allows for Hardware
+        Rendering with the GPU typically needed for 3D visualization using
+        VirtualGL. There are currently only 128 of these nodes on Oakley.
+      - **gpu** -  (*12 cores*) This node includes an NVIDIA Tesla M2070 GPU
+        allowing for CUDA computations. There are currently only 128 of these
+        nodes on Oakley. These nodes don't start an X server, so visualization
+        with hardware rendering is not possible.
+      - **bigmem** - (*12 cores*) This Oakley node comes with 192GB of
+        available RAM. There are only 8 of these nodes on Oakley.
+      - **hugemem** - (*32 cores*) This Oakley node has 1TB of available RAM as
+        well as 32 cores. There is only 1 of these nodes on Oakley. A
+        reservation may be required to use this node.
+    options:
+      - ["any", ":ppn=12"]
+      - ["vis", ":ppn=12:vis:gpus=1"]
+      - ["gpu", ":ppn=12:gpus=1"]
+      - ["bigmem", ":ppn=12:bigmem"]
+      - ["hugemem", ":ppn=32:hugemem"]
+submit: submit/pbs.yml.erb

--- a/test/fixtures/sys_with_interactive_apps/bc_jupyter/form.yml
+++ b/test/fixtures/sys_with_interactive_apps/bc_jupyter/form.yml
@@ -1,0 +1,29 @@
+---
+title: "Jupyter Notebook"
+cluster: "owens"
+description: |
+  This app will launch a Jupyter Notebook server on one or more Owens nodes.
+attributes:
+  bc_account:
+    help: "You can leave this blank if **not** in multiple projects."
+  node_type:
+    widget: select
+    label: "Node type"
+    help: |
+      - **any** - (*28 cores*) Chooses anyone of the available Owens nodes.
+        This reduces the wait time as you have no requirements.
+      - **gpu** -  (*28 cores*) This node includes an NVIDIA Tesla P100 GPU
+        allowing for CUDA computations. There are currently only 160 of these
+        nodes on Owens.
+      - **hugemem** - (*48 cores*) This Owens node has 1.5TB of available RAM
+        as well as 48 cores. There are 16 of these nodes on Owens.
+    options:
+      - ["any", ":ppn=28"]
+      - ["gpu", ":ppn=28:gpus=1"]
+      - ["hugemem", ":ppn=48:hugemem"]
+form:
+  - bc_num_hours
+  - bc_num_slots
+  - node_type
+  - bc_account
+  - bc_email_on_started

--- a/test/fixtures/sys_with_interactive_apps/bc_paraview/form.yml
+++ b/test/fixtures/sys_with_interactive_apps/bc_paraview/form.yml
@@ -1,0 +1,15 @@
+---
+title: "Paraview"
+cluster: "quick"
+description: |
+  This app will launch Paraview on an Owens **shared node**. You will be able
+  to interact with Paraview through a VNC session.
+attributes:
+  bc_vnc_resolution:
+    required: true
+  bc_account:
+    help: "You can leave this blank if **not** in multiple projects."
+form:
+  - bc_num_hours
+  - bc_account
+  - bc_vnc_resolution

--- a/test/models/batch_connect/app_test.rb
+++ b/test/models/batch_connect/app_test.rb
@@ -21,11 +21,35 @@ class BatchConnect::AppTest < ActiveSupport::TestCase
     }
   end
 
-  test "test default app title" do
+  test "default app title" do
     Dir.mktmpdir { |dir|
       r = PathRouter.new(dir + "/missing_app")
       assert_equal "Missing App", BatchConnect::App.new(router: r).title
       assert_equal "Owens Vdi", BatchConnect::App.new(router: r, sub_app: "owens-vdi").title
     }
+  end
+
+  test "sub_apps_list doesn't crash when local directory inaccessible" do
+    begin
+      # place in begin/ensure so we can delete the directory after setting
+      # back the permissions to 0700 on the local sub directory
+      # the normal Dir.mktmpdir {} would result in an exception being thrown
+      # when deleting the directories at the end of the test run
+      #
+      appdir = Pathname.new(Dir.mktmpdir)
+
+      # create local dir but make it inaccessible
+      localdir = appdir.join("local")
+      localdir.mkdir
+      localdir.chmod(0000)
+
+      app = BatchConnect::App.new(router: PathRouter.new(appdir))
+
+      assert 1, app.sub_app_list.count
+      assert_equal app, app.sub_app_list.first
+    ensure
+      localdir.chmod(0700)
+      appdir.rmtree
+    end
   end
 end

--- a/test/models/batch_connect/app_test.rb
+++ b/test/models/batch_connect/app_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class BatchConnect::AppTest < ActiveSupport::TestCase
+  test "app with malformed form.yml" do
+    Dir.mktmpdir { |dir|
+      r = PathRouter.new(dir)
+      r.path.join("form.yml").write("--x-\nnot a valid form yaml")
+
+      app = BatchConnect::App.new(router: r)
+
+      assert_equal "No title set", app.title
+      assert ! app.valid?
+    }
+  end
+
+  test "missing app handled gracefully" do
+    Dir.mktmpdir { |dir|
+      r = PathRouter.new(dir + "/missing_app")
+      app = BatchConnect::App.new(router: r)
+
+      assert_equal "No title set", app.title
+      assert ! app.valid?
+      assert_match /app does not supply.*a form file/, app.validation_reason
+    }
+  end
+end

--- a/test/models/batch_connect/app_test.rb
+++ b/test/models/batch_connect/app_test.rb
@@ -7,8 +7,6 @@ class BatchConnect::AppTest < ActiveSupport::TestCase
       r.path.join("form.yml").write("--x-\nnot a valid form yaml")
 
       app = BatchConnect::App.new(router: r)
-
-      assert_equal "No title set", app.title
       assert ! app.valid?
     }
   end
@@ -18,9 +16,16 @@ class BatchConnect::AppTest < ActiveSupport::TestCase
       r = PathRouter.new(dir + "/missing_app")
       app = BatchConnect::App.new(router: r)
 
-      assert_equal "No title set", app.title
       assert ! app.valid?
       assert_match /app does not supply.*a form file/, app.validation_reason
+    }
+  end
+
+  test "test default app title" do
+    Dir.mktmpdir { |dir|
+      r = PathRouter.new(dir + "/missing_app")
+      assert_equal "Missing App", BatchConnect::App.new(router: r).title
+      assert_equal "Owens Vdi", BatchConnect::App.new(router: r, sub_app: "owens-vdi").title
     }
   end
 end

--- a/test/models/manifest_test.rb
+++ b/test/models/manifest_test.rb
@@ -32,31 +32,37 @@ class ManifestTest < ActiveSupport::TestCase
   end
 
   test "save a valid manifest" do
-    manifest_file = Tempfile.new('manifest.yml', Dir.mktmpdir).path
-    manifest = Manifest.load("test/fixtures/files/manifest_valid")
-    save_result = manifest.save(manifest_file)
-    new_manifest = Manifest.load(manifest_file)
-    assert_equal true, save_result, "Result should save"
-    assert_instance_of Manifest, new_manifest, "Not a Manifest Object"
-    assert_equal manifest.to_yaml, new_manifest.to_yaml, "The saved manifest does not match the original"
+    Dir.mktmpdir { |dir|
+      manifest_file = Tempfile.new('manifest.yml', dir).path
+      manifest = Manifest.load("test/fixtures/files/manifest_valid")
+      save_result = manifest.save(manifest_file)
+      new_manifest = Manifest.load(manifest_file)
+      assert_equal true, save_result, "Result should save"
+      assert_instance_of Manifest, new_manifest, "Not a Manifest Object"
+      assert_equal manifest.to_yaml, new_manifest.to_yaml, "The saved manifest does not match the original"
+    }
   end
 
   test "save an InvalidManifest" do
-    manifest_file = Tempfile.new('manifest.yml', Dir.mktmpdir).path
-    manifest = Manifest.load("test/fixtures/files/manifest_invalid")
-    save_result = manifest.save(manifest_file + "empty")
-    new_manifest = Manifest.load(manifest_file + "empty")
-    assert_equal false, save_result, "Result should not save"
-    assert_instance_of MissingManifest, new_manifest, "Should not exist"
+    Dir.mktmpdir { |dir|
+      manifest_file = Tempfile.new('manifest.yml', dir).path
+      manifest = Manifest.load("test/fixtures/files/manifest_invalid")
+      save_result = manifest.save(manifest_file + "empty")
+      new_manifest = Manifest.load(manifest_file + "empty")
+      assert_equal false, save_result, "Result should not save"
+      assert_instance_of MissingManifest, new_manifest, "Should not exist"
+    }
   end
 
   test "save a MissingManifest" do
-    manifest_file = Tempfile.new('manifest.yml', Dir.mktmpdir).path
-    manifest = Manifest.load("test/fixtures/files/manifest_missing")
-    save_result = manifest.save(manifest_file + "empty")
-    new_manifest = Manifest.load(manifest_file + "empty")
-    assert_equal false, save_result, "Result should not save"
-    assert_instance_of MissingManifest, new_manifest, "Should not exist"
+    Dir.mktmpdir { |dir|
+      manifest_file = Tempfile.new('manifest.yml', dir).path
+      manifest = Manifest.load("test/fixtures/files/manifest_missing")
+      save_result = manifest.save(manifest_file + "empty")
+      new_manifest = Manifest.load(manifest_file + "empty")
+      assert_equal false, save_result, "Result should not save"
+      assert_instance_of MissingManifest, new_manifest, "Should not exist"
+    }
   end
 
   test "merge manifests" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 ENV['RAILS_ENV'] ||= 'test'
+ENV['OOD_CLUSTERS'] ||= 'test/fixtures/config/clusters.d'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 


### PR DESCRIPTION
A possible fix. It is currently brittle though. Calling `BatchConnect::App#title` may result in `AppNotFound` exception.

![screen shot 2017-06-15 at 3 29 32 pm](https://user-images.githubusercontent.com/512333/27198275-84613818-51df-11e7-9989-997c4ca5c373.png)

Also if the height of a window is 768px, what we often do for screenshots, the result is Jupyter app gets cut off:

![screen shot 2017-06-15 at 3 31 48 pm](https://user-images.githubusercontent.com/512333/27198334-c2b6eaa4-51df-11e7-9b86-402c56603488.png)

In this case, it might be preferable anyways to have subapps expand only when selected, by doing this:

![screen shot 2017-06-15 at 2 36 17 pm](https://user-images.githubusercontent.com/512333/27198362-d7eed558-51df-11e7-88e7-6dae063006ca.png)
