### PR TITLE
Add iHPC rake task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Added
+
+  - Can now submit iHPC session from command line using rake task.
+
 ## 1.13.3 (2017-06-23)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ See the wiki page https://github.com/OSC/ood-dashboard/wiki/App-Sharing
 You can launch an iHPC session by the command line using the provided rake
 task:
 
-```sh
-bin/rake batch_connect:new_session
+```
+batch_connect:new_session
 ```
 
 When you run the rake task, it will need to be run under the same environment
@@ -119,8 +119,12 @@ export RAILS_ENV=production
 export RAILS_RELATIVE_URL_ROOT=sys/dashboard
 
 # We launch our Owens desktop session
-bin/rake batch_connect:new_session BC_APP_TOKEN=sys/bc_desktop_v2/owens
+echo '{}' | bin/rake batch_connect:new_session BC_APP_TOKEN=sys/bc_desktop_v2/owens
 ```
+
+where you pipe in the JSON session context (basically a JSON representation of
+the form parameters you'd see in the web form when you tried to submit an iHPC
+session).
 
 If the session was launched successfully, then you should be able to navigate
 to the chosen Dashboard app in your browser and find your session under
@@ -129,10 +133,10 @@ to the chosen Dashboard app in your browser and find your session under
 ### Modify Session Context
 
 To modify the context that the session is launched with (e.g., modify number of
-nodes or walltime) you need to provide a JSON file with the settings you want
-to use.
+nodes or walltime) you need to provide a JSON formatted string to STDIN with
+the settings you want to use.
 
-For the case of the Owens desktop, a session context file can look like:
+For the case of the Owens desktop, a session context JSON string can look like:
 
 ```json
 {
@@ -145,14 +149,23 @@ For the case of the Owens desktop, a session context file can look like:
 }
 ```
 
-You can then launch and Owens desktop session with this JSON file as:
+You can then launch and Owens desktop session with this JSON string as:
 
 ```sh
 # Set environment for the Dashboard app of your choosing
 ...
 
 # Launch and Owens desktop session with user-defined context
-bin/rake batch_connect:new_session BC_APP_TOKEN=sys/bc_desktop_v2/owens BC_SESSION_CONTEXT=/path/to/context.json
+bin/rake batch_connect:new_session BC_APP_TOKEN=sys/bc_desktop_v2/owens <<-EOF
+{
+  "bc_num_hours": "1",
+  "bc_num_slots": "1",
+  "node_type": ":ppn=28",
+  "bc_account": "",
+  "bc_vnc_resolution": "2048x1152",
+  "bc_email_on_started": "0"
+}
+EOF
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -88,6 +88,73 @@ See the wiki page https://github.com/OSC/ood-dashboard/wiki/Site-Wide-Announceme
 
 See the wiki page https://github.com/OSC/ood-dashboard/wiki/App-Sharing
 
+## iHPC CLI
+
+You can launch an iHPC session by the command line using the provided rake
+task:
+
+```sh
+bin/rake batch_connect:new_session
+```
+
+When you run the rake task, it will need to be run under the same environment
+that the Dashboard **web** app is run under:
+
+- `PWD` will need to be the Dashboard App root
+- `RAILS_ENV` will need to be set to the rails environment the Dashboard App
+  would be run under
+- `RAILS_RELATIVE_URL_ROOT` will need to be set to what the Dashboard App would
+  use
+
+So an example to launch an Owens desktop that is deployed at OSC under the app
+token `sys/bc_desktop_v2/owens` using the system-installed Dashboard App
+(production) would be run as:
+
+```sh
+# We need to be at the root of the Dashboard app
+cd /var/www/ood/apps/sys/dashboard
+
+# We set the environment to match the Dashboard app's environment
+export RAILS_ENV=production
+export RAILS_RELATIVE_URL_ROOT=sys/dashboard
+
+# We launch our Owens desktop session
+bin/rake batch_connect:new_session BC_APP_TOKEN=sys/bc_desktop_v2/owens
+```
+
+If the session was launched successfully, then you should be able to navigate
+to the chosen Dashboard app in your browser and find your session under
+"Interactive Apps" => "Interactive Session".
+
+### Modify Session Context
+
+To modify the context that the session is launched with (e.g., modify number of
+nodes or walltime) you need to provide a JSON file with the settings you want
+to use.
+
+For the case of the Owens desktop, a session context file can look like:
+
+```json
+{
+  "bc_num_hours": "1",
+  "bc_num_slots": "1",
+  "node_type": ":ppn=28",
+  "bc_account": "",
+  "bc_vnc_resolution": "2048x1152",
+  "bc_email_on_started": "0"
+}
+```
+
+You can then launch and Owens desktop session with this JSON file as:
+
+```sh
+# Set environment for the Dashboard app of your choosing
+...
+
+# Launch and Owens desktop session with user-defined context
+bin/rake batch_connect:new_session BC_APP_TOKEN=sys/bc_desktop_v2/owens BC_SESSION_CONTEXT=/path/to/context.json
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at

--- a/lib/tasks/batch_connect.rake
+++ b/lib/tasks/batch_connect.rake
@@ -4,13 +4,7 @@ namespace :batch_connect do
     # Read in user settings
     app = ENV["BC_APP_TOKEN"] || abort("Missing environment variable BC_APP_TOKEN")
     fmt = ENV["BC_RENDER_FORMAT"]
-    ctx = if !$stdin.tty?
-            $stdin.read
-          elsif ENV["BC_SESSION_CONTEXT"]
-            File.read(ENV["BC_SESSION_CONTEXT"])
-          else
-            "{}"
-          end
+    ctx = $stdin.read
 
     # Initialize objects
     app   = BatchConnect::App.from_token app

--- a/lib/tasks/batch_connect.rake
+++ b/lib/tasks/batch_connect.rake
@@ -20,6 +20,12 @@ namespace :batch_connect do
 
     # Generate new session
     session = BatchConnect::Session.new
-    session.save(app: app, context: session_ctx, format: fmt)
+    unless session.save(app: app, context: session_ctx, format: fmt)
+      error_msg = "Failed to launch session with following errors:\n\n"
+      session.errors.full_messages.each do |error|
+        error_msg += "  - #{error.gsub(/\n/, "\n    ")}\n\n"
+      end
+      abort error_msg
+    end
   end
 end

--- a/lib/tasks/batch_connect.rake
+++ b/lib/tasks/batch_connect.rake
@@ -3,14 +3,20 @@ namespace :batch_connect do
   task new_session: :environment do
     # Read in user settings
     app = ENV["BC_APP_TOKEN"] || abort("Missing environment variable BC_APP_TOKEN")
-    ctx = ENV["BC_SESSION_CONTEXT"]
     fmt = ENV["BC_RENDER_FORMAT"]
+    ctx = if !$stdin.tty?
+            $stdin.read
+          elsif ENV["BC_SESSION_CONTEXT"]
+            File.read(ENV["BC_SESSION_CONTEXT"])
+          else
+            "{}"
+          end
 
     # Initialize objects
     app   = BatchConnect::App.from_token app
     fmt ||= app.cluster.job_config[:adapter] if app.cluster
     session_ctx = app.build_session_context
-    session_ctx.from_json( ctx ? File.read(ctx) : "{}" )
+    session_ctx.from_json(ctx)
 
     # Generate new session
     session = BatchConnect::Session.new

--- a/lib/tasks/batch_connect.rake
+++ b/lib/tasks/batch_connect.rake
@@ -1,0 +1,19 @@
+namespace :batch_connect do
+  desc "Generate new batch connect session"
+  task new_session: :environment do
+    # Read in user settings
+    app = ENV["BC_APP_TOKEN"] || abort("Missing environment variable BC_APP_TOKEN")
+    ctx = ENV["BC_SESSION_CONTEXT"]
+    fmt = ENV["BC_RENDER_FORMAT"]
+
+    # Initialize objects
+    app   = BatchConnect::App.from_token app
+    fmt ||= app.cluster.job_config[:adapter] if app.cluster
+    session_ctx = app.build_session_context
+    session_ctx.from_json( ctx ? File.read(ctx) : "{}" )
+
+    # Generate new session
+    session = BatchConnect::Session.new
+    session.save(app: app, context: session_ctx, format: fmt)
+  end
+end


### PR DESCRIPTION
Provides the capability to launch an iHPC session from the command line using a Rake task. See modified `README.md` for more details.