### PR TITLE
Added safari alert message

### DIFF
--- a/.env.local.osc
+++ b/.env.local.osc
@@ -8,3 +8,4 @@ OOD_DASHBOARD_SUPPORT_URL="https://www.osc.edu/contact/supercomputing_support"
 OOD_DASHBOARD_SUPPORT_EMAIL="oschelp@osc.edu"
 
 ENABLE_NATIVE_VNC=1
+DISABLE_SAFARI_BASIC_AUTH_WARNING=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+### Added
+
+  - Added a unsupported browser alert for Safari by default due to Basic Auth
+    and websocket issue.
+
 ### Fixed
 
   - Moved `batch_connect` dataroot to properly namespaced directory. [#188](https://github.com/OSC/ood-dashboard/issues/181)

--- a/README.md
+++ b/README.md
@@ -88,6 +88,28 @@ See the wiki page https://github.com/OSC/ood-dashboard/wiki/Site-Wide-Announceme
 
 See the wiki page https://github.com/OSC/ood-dashboard/wiki/App-Sharing
 
+### Safari Warning
+
+We currently display an alert message at the top of the Dashboard mentioning
+that we don't currently support the Safari browser. This is because of an issue
+in Safari where it fails to connect to websockets if the Apache proxy uses
+Basic Auth for user authentication (on by default for new OOD installations).
+
+If you ever change the authentication mechanism to a cookie-based mechanism
+(e.g., Shibboleth or OpenID Connect), then it is recommended you disable this
+alert message in the dashboard.
+
+You can do this by modifying the `.env.local` file as such:
+
+```sh
+# .env.local
+
+# ... all of your other settings ...
+
+# Set this to disable Safari + Basic Auth warning
+DISABLE_SAFARI_BASIC_AUTH_WARNING=1
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,6 +43,18 @@
       </div>
     <% end %>
 
+    <% if !ENV["DISABLE_SAFARI_BASIC_AUTH_WARNING"] && browser.safari? %>
+      <div class="alert alert-danger alert-dismissible" role="alert">
+        <button type="button" class="close" data-dismiss="alert">
+          <span aria-hidden="true">&times;</span>
+          <span class="sr-only">Close</span>
+        </button>
+        OnDemand currently does not support the Safari browser at this time.
+        Not all applications will work currently with this browser, it is
+        recommended that you use a different browser.
+      </div>
+    <% end %>
+
     <script type="text/coffee-script-template" id="js-alert-danger-template">
       <div class="alert alert-danger alert-dismissible" role="alert">
         <button type="button" class="close" data-dismiss="alert">


### PR DESCRIPTION
Added alert message to address Safari browsers that cannot connect to websockets due to using basic access authentication for user authentication in the Apache proxy.

This is toggle-able through the environment variable `DISABLE_SAFARI_BASIC_AUTH_WARNING`.

@ericfranz: Feel free to change the message displayed to the users however you see fit.