### PR TITLE
Add a timeout to the path check to speed up load on hanging filesystem

### DIFF
--- a/app/apps/ood_files_app.rb
+++ b/app/apps/ood_files_app.rb
@@ -19,7 +19,17 @@ class OodFilesApp
   # returns an array of other paths provided as shortcuts to the user
   def favorite_paths
     @favorite_paths ||= candidate_favorite_paths.select {|p|
-      p.directory? && p.readable? && p.executable?
+      path_valid p
     }
+  end
+
+  private
+
+  def path_valid(path)
+    Timeout.timeout(3) {
+      path.directory? && path.readable? && path.executable?
+    }
+  rescue Timeout::Error => e
+    false
   end
 end


### PR DESCRIPTION
Alternative to https://github.com/OSC/ood-dashboard/pull/157

This adds a timeout around the filesystem check. Currently at 3 seconds, but that's arbitrary.

The negatives of this solution are that if the system is slow it won't show the additional paths, even if they may be available, and also that the page will still hang for a few seconds (but not 30) when the paths are unresponsive.

The positive is obviously that it's simple and completely server-side.

