### PR TITLE
Add apps to develop nav

### DIFF
--- a/app/apps/ood_app.rb
+++ b/app/apps/ood_app.rb
@@ -23,6 +23,18 @@ class OodApp
     manifest.name.empty? ? name.titleize : manifest.name
   end
 
+  def modified_at
+    # FIXME: ideally, we look at all the versioned files
+    # and see if one changed, or look at the tmp/restart dir
+    # or look at the git dir or any file that is appropriate
+    # or if git has a last modified date tool...
+    # right now, you can change files underneath, access the app
+    # and since the directory hasn't been touched
+    # the modified date ! change
+    # File.mtime(path)
+    @modified_at ||= path.mtime
+  end
+
   def url
     if manifest.url.empty?
       if batch_connect_app?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  before_filter :set_user, :set_nav_groups, :set_announcement
+  before_filter :set_user, :set_nav_groups, :set_announcement, :set_recent_dev_apps
 
   def set_user
     @user = User.new
@@ -12,6 +12,21 @@ class ApplicationController < ActionController::Base
   def set_nav_groups
     #TODO: for AweSim, what if we added the shared apps here?
     @nav_groups = OodAppGroup.select(titles: NavConfig.categories, groups: sys_app_groups)
+  end
+
+  # get a list of recent dev apps the current user has access to (up to 8)
+  def set_recent_dev_apps
+    # FIXME: really, what i want to know is if user.developer?
+    # and have a method to get a list of dev apps, and a list of recently
+    # accessed apps, for a given user (i.e. the current user)
+    #
+    if NavConfig.show_develop_dropdown
+      @recent_dev_apps = DevRouter.apps(require_manifest: false).sort_by {|a|
+        a.modified_at.to_i
+      }.reverse[0,6]
+    else
+      []
+    end
   end
 
   def sys_app_groups

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,7 +1,7 @@
 class Product
   include ActiveModel::Model
 
-  delegate :passenger_rack_app?, :passenger_rails_app?, :passenger_app?, :can_run_bundle_install?, to: :app
+  delegate :passenger_rack_app?, :passenger_rails_app?, :passenger_app?, :can_run_bundle_install?, :modified_at, to: :app
 
   attr_accessor :name
   attr_accessor :found
@@ -104,7 +104,7 @@ class Product
   end
 
   def app
-    OodApp.new(router)
+    @app ||= OodApp.new(router)
   end
 
   def gemfile

--- a/app/views/layouts/nav/_develop_dropdown.html.erb
+++ b/app/views/layouts/nav/_develop_dropdown.html.erb
@@ -7,5 +7,16 @@
     <li><a href="<%= ENV['OOD_DASHBOARD_DEV_DOCS_URL'] %>" target="_blank"><i class="fa fa-book"></i> Developer Documentation</a></li>
     <li><a href="<%=  products_path(type: "dev") %>"><i class="fa fa-gear"></i> <%= products_title(:dev) %></a></li>
     <li><a href="<%= products_path(type: "usr") %>"><i class="fa fa-share-alt"></i> <%= products_title(:usr) %></a></li>
+
+
+    <%# show recent sandbox apps list items %>
+    <% if @recent_dev_apps.any? %>
+      <%= content_tag "li", "", class: "divider", role: "separator"  %>
+      <%= content_tag :li, "Recent Sandbox Apps", class: "dropdown-header" %>
+
+      <% @recent_dev_apps.each_with_index do |app, idx| %>
+        <li><a href="<%= product_path(app.name, type: "dev") %>"><%= app_icon_tag(app) %> <%= "#{app.title} (#{app.name})" %></a></li>
+      <% end %>
+    <% end %>
   </ul>
 </li>

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -1,4 +1,3 @@
-<% modified_time = File.mtime(product.router.path) %>
 <tr>
   <td>
     <%= app_icon_tag(product.app) %>
@@ -21,7 +20,7 @@
     </div>
     <% end %>
   </td>
-  <td data-order="<%= modified_time.to_i %>"><%= modified_time.strftime("%m/%d/%y") %></td>
+  <td data-order="<%= product.modified_at.to_i %>"><%= product.modified_at.strftime("%m/%d/%y") %></td>
   <td>
     <%= link_to 'Shell', OodAppkit.shell.url(host: ENV['OOD_DEV_SSH_HOST'], path: product.router.path.realdirpath).to_s, target: '_blank', class: 'btn btn-default btn-block' %>
     <%= link_to 'Files', OodAppkit.files.url(path: product.router.path.realdirpath).to_s, target: '_blank', class: 'btn btn-default btn-block' %>


### PR DESCRIPTION
Show up to 6 recent apps:

<img width="993" alt="screen 2017-08-11 at 8 10 48 pm" src="https://user-images.githubusercontent.com/512333/29235873-3379704a-7ed1-11e7-9fb1-f70bcbb1eb45.png">

Two problems with this solution:

1. (minor) when going to the sandbox apps index page `ProductsController#index` the list of apps is built twice
2. (major) OodApp#modified_at just gets the modified date of the directory which does not change when you do any of these actions:
   1. change a file in that directory
   2. touch tmp/restart.txt to restart the app
   3. launch the app
   4. go to the details page of the app

For this reason, this feature would only become useful if we used another value besides the directory modified date. This is a similar problem of sorting by modified date in the apps list. Also, it might be preferable, instead, for the user to **star** specific apps as "favorites" and then for those to appear in the menu.