### PR TITLE
Add products launch button

### DIFF
--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -5,7 +5,7 @@
   </td>
   <td><%= product.name %></td>
   <td>
-    <%= link_to product.title, app_path(product.app.name, product.app.type, product.app.owner) %>
+    <%= link_to product.title, app_path(product.app.name, product.app.type, product.app.owner), target: "_blank" %>
     <% if product.git_repo? %>
       <span class="text-muted">[<%= product.version %>]</span>
     <% end %>

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -21,6 +21,9 @@
     </div>
     <% end %>
   </td>
+  <td>
+    <%= link_to "Launch #{product.title}", app_path(product.app.name, product.app.type, product.app.owner), target: '_blank', class: 'btn btn-primary' %>
+  </td>
   <td data-order="<%= modified_time.to_i %>"><%= modified_time.strftime("%m/%d/%y") %></td>
   <td>
     <%= link_to 'Shell', OodAppkit.shell.url(host: ENV['OOD_DEV_SSH_HOST'], path: product.router.path.realdirpath).to_s, target: '_blank', class: 'btn btn-default btn-block' %>

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -26,11 +26,10 @@
   </td>
   <td data-order="<%= modified_time.to_i %>"><%= modified_time.strftime("%m/%d/%y") %></td>
   <td>
+    <%= link_to 'Details', product_path(product.name, type: @type), class: 'btn btn-info btn-block' %>
     <%= link_to 'Shell', OodAppkit.shell.url(host: ENV['OOD_DEV_SSH_HOST'], path: product.router.path.realdirpath).to_s, target: '_blank', class: 'btn btn-default btn-block' %>
     <%= link_to 'Files', OodAppkit.files.url(path: product.router.path.realdirpath).to_s, target: '_blank', class: 'btn btn-default btn-block' %>
   </td>
   <td>
-    <%= link_to 'Details', product_path(product.name, type: @type), class: 'btn btn-info btn-block' %>
-    <%= link_to 'Edit', edit_product_path(product.name, type: @type), class: 'btn btn-default btn-block' %>
   </td>
 </tr>

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -5,7 +5,7 @@
   </td>
   <td><%= product.name %></td>
   <td>
-    <%= link_to product.title, app_path(product.app.name, product.app.type, product.app.owner), target: "_blank" %>
+    <%= link_to product.title, product_path(product.name, type: @type) %>
     <% if product.git_repo? %>
       <span class="text-muted">[<%= product.version %>]</span>
     <% end %>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -25,6 +25,7 @@
       <th data-orderable="false" data-searchable="false"></th>
       <th>Directory Name</th>
       <th>App Details</th>
+      <th data-orderable="false" data-searchable="false"></th>
       <th>Last Modified</th>
       <th data-orderable="false" data-searchable="false"></th>
       <th data-orderable="false" data-searchable="false"></th>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -47,6 +47,9 @@
       <strong>Description:</strong><br/>
       <%= manifest_markdown(@product.app.manifest.description) %>
     </p>
+    <p>
+      <%= link_to 'Edit', edit_product_path(@product.name, type: @type), class: 'btn btn-default' %>
+    </p>
   </div><!-- /.col-md-6 -->
   <div class="col-md-2 col-xs-6">
     <%= command_btn(title: "Bundle Install", key: "bundle_install", display:"scl enable rh-ruby22 nodejs010 -- bin/bundle install --path=vendor/bundle") if @product.can_run_bundle_install? %>
@@ -128,7 +131,6 @@
 <hr />
 <% end %>
 
-<%= link_to 'Edit', edit_product_path(@product.name, type: @type), class: 'btn btn-default' %>
 <%= link_to 'Back', products_path(type: @type), class: 'btn btn-default' %>
 <%= link_to 'Delete App',
   product_path(@product.name, type: @type),

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -17,8 +17,11 @@
   </div><!-- /.col-md-2 -->
   <div class="col-md-6 col-sm-10 col-xs-12">
     <p>
+      <%= link_to "Launch #{@product.app.title}", app_path(@product.app.name, @product.app.type, @product.app.owner), target: '_blank', class: 'btn btn-primary' %>
+    </p>
+    <p>
       <strong>Title:</strong>
-      <%= link_to @product.app.title, app_path(@product.app.name, @product.app.type, @product.app.owner), target: '_blank'%>
+      <%= @product.app.title %>
     </p>
     <p>
       <span data-toggle="popover" data-trigger="hover" data-placement="bottom" title="Active Users" data-content="<%= @product.active_users.join("<br />") %>" data-html="true">


### PR DESCRIPTION
Fixes #210 

Several changes:

1. move Edit button under details view next to description etc (fields that it modifies)
2. add launch button to details and list view
3. remove Edit button from list view (which doesn't make as much since now) and instead just show Details button
4. Stack details button on top of other btns
5. change title link to now take you to details, since there is a dedicated launch button

![screen 2017-08-29 at 1 42 32 pm](https://user-images.githubusercontent.com/512333/29835488-2854359a-8cc0-11e7-8c16-9eb4c8a3d1a1.png)
![screen 2017-08-29 at 1 42 27 pm](https://user-images.githubusercontent.com/512333/29835487-28536746-8cc0-11e7-913b-77a57897519d.png)
