### PR TITLE
New config obj

### DIFF
--- a/app/apps/nav_config.rb
+++ b/app/apps/nav_config.rb
@@ -1,8 +1,6 @@
 class NavConfig
   class << self
     attr_accessor :categories
-    attr_accessor :show_develop_dropdown
   end
   self.categories = ["Files", "Jobs", "Clusters", "Interactive Apps"]
-  self.show_develop_dropdown = ENV['OOD_APP_DEVELOPMENT'].present?
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,7 @@
         </ul>
         <div class="navbar-right">
           <ul class="nav navbar-nav">
-            <%= render partial: 'layouts/nav/develop_dropdown' if NavConfig.show_develop_dropdown %>
+            <%= render partial: 'layouts/nav/develop_dropdown' if Configuration.app_development_enabled? %>
             <%= render partial: "layouts/nav/help_dropdown" %>
           </ul>
           <p class="navbar-text" data-toggle="popover" data-content="Logged in as <%= @user.name %>" data-placement="bottom" >

--- a/app/views/layouts/nav/_develop_dropdown.html.erb
+++ b/app/views/layouts/nav/_develop_dropdown.html.erb
@@ -6,7 +6,7 @@
     <li><a href="<%= restart_url %>"><i class="fa fa-refresh"></i> Restart Web Server</a></li>
     <li><a href="<%= ENV['OOD_DASHBOARD_DEV_DOCS_URL'] %>" target="_blank"><i class="fa fa-book"></i> Developer Documentation</a></li>
     <li><a href="<%=  products_path(type: "dev") %>"><i class="fa fa-gear"></i> <%= products_title(:dev) %></a></li>
-    <% if ENV["OOD_APP_SHARING"].present? %>
+    <% if Configuration.app_sharing_enabled? %>
         <li><a href="<%= products_path(type: "usr") %>"><i class="fa fa-share-alt"></i> <%= products_title(:usr) %></a></li>
     <% end %>
   </ul>

--- a/config/configuration.rb
+++ b/config/configuration.rb
@@ -1,0 +1,17 @@
+# dashboard app specific configuration
+class Configuration
+  class << self
+    attr_writer :app_development_enabled
+    attr_writer :app_sharing_enabled
+
+    def app_development_enabled?
+      return @app_development_enabled if defined? @app_development_enabled
+      @app_development_enabled = ENV['OOD_APP_DEVELOPMENT'].present?
+    end
+
+    def app_sharing_enabled?
+      return @app_sharing_enabled if defined? @app_sharing_enabled
+      @app_sharing_enabled = ENV['OOD_APP_SHARING'].present?
+    end
+  end
+end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,8 @@
 # Load the Rails application.
 require File.expand_path('../application', __FILE__)
 
+# Load the dashboard specific configuration.
+require File.expand_path('../configuration', __FILE__)
+
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/config/initializers/ood.rb.osc.awesim
+++ b/config/initializers/ood.rb.osc.awesim
@@ -11,7 +11,7 @@ OodFilesApp.candidate_favorite_paths.tap do |paths|
 end
 
 # don't show develop dropdown unless you are setup for app sharing
-NavConfig.show_develop_dropdown = UsrRouter.base_path.directory?
+Configuration.app_development_enabled = UsrRouter.base_path.directory?
 
 # uncomment if you want to revert to the old menu
 # NavConfig.categories = ["Files", "Jobs", "Clusters", "Desktops", "Desktop Apps"]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
   get "apps/show/:name(/:type(/:owner))" => "apps#show", as: "app", defaults: { type: "sys" }
   get "apps/icon/:name(/:type(/:owner))" => "apps#icon", as: "app_icon", defaults: { type: "sys" }
 
-  if ENV['OOD_APP_SHARING'].present?
+  if Configuration.app_sharing_enabled?
     # TODO:
     # is there a cleaner approach to this? an app should be a resource
     get "apps(/index(/:type(/:owner)))" => "apps#index", as: "apps", defaults: { type: "usr" }
@@ -26,7 +26,7 @@ Rails.application.routes.draw do
   end
 
   #FIXME: undo when ready to deploy app sharing to production, remove?
-  if ENV['OOD_APP_DEVELOPMENT'].present?
+  if Configuration.app_development_enabled?
     # App administration
     scope 'admin/:type' do
       resources :products, param: :name, constraints: { type: /dev|usr/ } do


### PR DESCRIPTION
Fixes https://github.com/OSC/ood-dashboard/issues/236 and https://github.com/OSC/ood-dashboard/issues/235

Provides a new Configuration object that we can eventually:

1. move all domain specific configuration to
2. set sensible defaults from env vars
3. load a YAML config from /etc/config to set these values using a single YAML file instead of separate ENV vars

For now, only added app_development_enabled? and app_sharing_enabled?