### PR TITLE
Logs command line calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Logs the full command line call for any forked processes.
+  [#260](https://github.com/OSC/ood-dashboard/issues/260)
+
 ### Changed
 - (Batch Connect) Check boxes are now placed inside of `form_group`.
   [#266](https://github.com/OSC/ood-dashboard/issues/266)

--- a/config/initializers/open3_extensions.rb
+++ b/config/initializers/open3_extensions.rb
@@ -1,0 +1,8 @@
+module Open3Extensions
+  def capture3(*cmd, **opts)
+    Rails.logger.error("CMD: #{cmd}")
+    super
+  end
+end
+
+Open3.singleton_class.prepend Open3Extensions

--- a/config/initializers/open3_extensions.rb
+++ b/config/initializers/open3_extensions.rb
@@ -1,6 +1,7 @@
 module Open3Extensions
   def capture3(*cmd, **opts)
-    Rails.logger.error("CMD: #{cmd}")
+    # FIXME: Taking educated guess on what Splunk wants in the logs
+    Rails.logger.error(%[execve="#{cmd.to_s.gsub('"', '\"')}"])
     super
   end
 end


### PR DESCRIPTION
Fixes #260 

This performs a very *gentle* monkey patch of the `Open3::capture3` call which is what all the adapters currently use (aside from the few library calls in the Torque adapter).

The logs look like:

```
CMD: [{"PBS_DEFAULT"=>"owens-batch.ten.osc.edu", "LD_LIBRARY_PATH"=>"/opt/torque/lib64:/opt/rh/v8314/root/usr/lib64:/opt/rh/nodejs010/root/usr/lib64:/opt/rh/rh-ruby22/root/usr/lib64:/opt/rh/rh-passenger40/root/usr/lib64"}, "/opt/torque/bin/qsub", "-d", "/users/appl/jnicklas/ondemand/dev/ood-dashboard/data/batch_connect/sys/bc_osc_jupyter_spark/output/438cedea-3fc4-42bb-8d8f-891dac21d810", "-N", "ondemand2/dev/ood-dashboard/sys/bc_osc_jupyter_spark", "-o", "/users/appl/jnicklas/ondemand/dev/ood-dashboard/data/batch_connect/sys/bc_osc_jupyter_spark/output/438cedea-3fc4-42bb-8d8f-891dac21d810/output.log", "-j", "oe", "-A", "PZS0002", "-S", "/bin/bash", "-l", "walltime=01:00:00", "-l", "nodes=1:ppn=28", "/tmp/qsub.20171013-12546-ka1ki2"]
```