### PR TITLE
[DO NOT MERGE] Simple example with configuration in global location

### DIFF
--- a/app/models/motd_file.rb
+++ b/app/models/motd_file.rb
@@ -7,7 +7,7 @@ class MotdFile
   # Initialize the Motd Controller object based on the current user.
   #
   # @param [String] path The path to the motd file as a URI
-  def initialize(path = ENV['MOTD_PATH'])
+  def initialize(path = Configuration.motd_path)
     @motd_path = path
     @content = load(path)
   end
@@ -34,7 +34,7 @@ class MotdFile
   # @return [Object, nil] an MotdFormatter object that responds to `:to_partial_path`
   #                       `nil` if a file does not exist at the path.
   def formatter
-    case ENV['MOTD_FORMAT']
+    case Configuration.motd_format
       when 'osc'
         @motd = MotdFormatterOsc.new(self)
       when 'markdown'

--- a/config/configuration.rb
+++ b/config/configuration.rb
@@ -19,5 +19,45 @@ class Configuration
       @app_sharing_enabled = ENV['OOD_APP_SHARING'].present?
     end
     alias_method :app_sharing_enabled, :app_sharing_enabled?
+
+    # The app's configuration root directory
+    # @return [Pathname] path to configuration root
+    def config_root
+      Pathname.new(ENV["OOD_CONFIG"] || "/etc/ood/config/apps/dashboard")
+    end
+
+    # A hash describing the configuration read in from the app's configuration
+    # file
+    # @return [Hash{Symbol=>Object}] configuration hash
+    def config
+      yaml = config_root.join("config.yml")
+      config = yaml.exist? ? YAML.load(ERB.new(yaml.read, nil, "-").result) : {}
+
+      if config.is_a?(Hash)
+        config.compact.deep_symbolize_keys
+      else
+        Rails.logger.error("ERROR: Configuration file '#{yaml}' needs to define a Hash")
+        {}
+      end
+    rescue Psych::SyntaxError => e
+      Rails.logger.error("ERROR: YAML syntax error occurred while parsing #{yaml} - #{e.message}")
+      {}
+    end
+
+    # The path to the motd file
+    # @return [String, nil] motd path
+    def motd_path
+      ENV["MOTD_PATH"] || config[:motd_path].try(:to_s)
+    end
+
+    # Format to display motd
+    # @return [String, nil] motd format
+    def motd_format
+      ENV["MOTD_FORMAT"] || config[:motd_format].try(:to_s)
+    end
   end
+end
+
+Rails.application.configure do |config|
+  config.paths["config/initializers"] << Configuration.config_root.join("initializers").to_s
 end


### PR DESCRIPTION
@ericfranz here is an example that maintains backwards compatibility but allows for a YAML (ERB rendered) configuration file located at:

```
/etc/ood/config/apps/dashboard/config.yml
```

and any initializers under:

```
/etc/ood/config/apps/dashboard/initializers/**/*.rb
```

I do not cache the configuration as it is typically read from local disk (so should be fast), and this allows for real-time updating of the Dashboard. Although it wouldn't be hard to add caching if you prefer.

> **NOTE:**
> You can override the location of the above files by adding the following line to your `.env.local`:
>
> ```bash
> OOD_CONFIG=/path/to/new/config_root
> ```
>
> and it will look for:
>
> ```
> /path/to/new/config_root/config.yml
> /path/to/new/config_root/initializers/**/*.rb
> ```