### PR TITLE
Add support for YAML announcements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added support for YAML announcements with ERB syntax as well as handling for
+  multiple announcements.
+  [#306](https://github.com/OSC/ood-dashboard/issues/306)
 
 ## [1.20.0] - 2017-12-21
 ### Added

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,7 +19,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_announcements
-    @announcements = Announcements.all
+    @announcements = Announcements.all(Configuration.announcement_path)
   rescue => e
     logger.warn "Error parsing announcements: #{e.message}"
     @announcements = []

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  before_filter :set_user, :set_nav_groups, :set_announcement
+  before_filter :set_user, :set_nav_groups, :set_announcements
 
   def set_user
     @user = User.new
@@ -18,10 +18,10 @@ class ApplicationController < ActionController::Base
     @sys_app_groups ||= OodAppGroup.groups_for(apps: SysRouter.apps)
   end
 
-  def set_announcement
-    path = Pathname.new(ENV["OOD_ANNOUNCEMENT_PATH"] || "/etc/ood/config/announcement.md")
-    @announcement = path.read if path.file?
+  def set_announcements
+    @announcements = Announcements.all
   rescue => e
-    logger.warn "Failed to read announcement file at: #{path} with error: #{e.message}"
+    logger.warn "Error parsing announcements: #{e.message}"
+    @announcements = []
   end
 end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -30,8 +30,8 @@ class Announcement
   end
 
   # @param opts [#to_h] the announcement object
-  # @option opts [#to_sym] :type (:info) Type of announcement (:info, :success,
-  #   :warning, :danger)
+  # @option opts [#to_sym] :type (:warning) Type of announcement (:info,
+  #   :success, :warning, :danger)
   # @option opts [#to_s] :msg (nil) The announcement message
   def initialize(opts = {})
     opts = opts.to_h.symbolize_keys.compact

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -13,18 +13,21 @@ class Announcement
   class << self
     # Parse a file
     # @param path [#to_s] path to file
-    # @return [Announcement, nil] announcement if able to parse
+    # @return [Announcement] announcement object
     def parse(path)
       path = Pathname.new(path.to_s).expand_path
-      return nil unless path.readable?
 
-      case path.extname
-      when ".md"
-        Announcement.new(msg: path.read)
-      when ".yml"
-        Announcement.new(YAML.safe_load(ERB.new(path.read, nil, "-").result))
+      if path.file? && path.readable?
+        case path.extname
+        when ".md"
+          Announcement.new(msg: path.read)
+        when ".yml"
+          Announcement.new(YAML.safe_load(ERB.new(path.read, nil, "-").result))
+        else
+          Announcement.new
+        end
       else
-        nil
+        Announcement.new
       end
     end
   end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,0 +1,51 @@
+class Announcement
+  # List of valid announcement types
+  TYPES = %i(warning info success danger)
+
+  # The announcement's message
+  # @return [String, nil] the announcement's message if it exists
+  attr_reader :msg
+
+  # The type of announcement
+  # @return [Symbol] the type of announcement
+  attr_reader :type
+
+  class << self
+    # Parse a file
+    # @param path [#to_s] path to file
+    # @return [Announcement, nil] announcement if able to parse
+    def parse(path)
+      path = Pathname.new(path.to_s).expand_path
+      return nil unless path.readable?
+
+      case path.extname
+      when ".md"
+        Announcement.new(msg: path.read)
+      when ".yml"
+        Announcement.new(YAML.safe_load(ERB.new(path.read, nil, "-").result))
+      else
+        nil
+      end
+    end
+  end
+
+  # @param opts [#to_h] the announcement object
+  # @option opts [#to_sym] :type (:info) Type of announcement (:info, :success,
+  #   :warning, :danger)
+  # @option opts [#to_s] :msg (nil) The announcement message
+  def initialize(opts = {})
+    opts = opts.to_h.symbolize_keys.compact
+
+    type  = opts.fetch(:type, TYPES.first).to_sym
+    @type = TYPES.include?(type) ? type : TYPES.first
+
+    msg   = opts.fetch(:msg, "").to_s
+    @msg  = msg.blank? ? nil : msg
+  end
+
+  # Whether this is a valid announcement
+  # @return [Boolean] whether it is valid
+  def valid?
+    !!msg
+  end
+end

--- a/app/models/announcements.rb
+++ b/app/models/announcements.rb
@@ -1,0 +1,41 @@
+class Announcements
+  include Enumerable
+
+  class << self
+    # Parse from an announcement path file/dir
+    # @param path [#to_s] announcement path
+    # @return [Announcements] the parsed announcements
+    def parse(path)
+      path = Pathname.new(path.to_s).expand_path
+
+      if path.directory?
+        paths = Pathname.glob(path.join("*.{md,yml}")).sort
+      else
+        paths = [path]
+      end
+
+      new( paths.map {|p| Announcement.parse(p)}.compact.select(&:valid?) )
+    end
+
+    # Build a list of announcements from files
+    # @return [Announcements] all announcements
+    def all
+      if path = Configuration.announcement_path
+        parse(path)
+      else
+        new
+      end
+    end
+  end
+
+  # @param announcements [Array<Announcement>] list of announcements
+  def initialize(announcements = [])
+    @announcements = announcements
+  end
+
+  # For a block {|announcement| ...}
+  # @yield [announcement] Gives the next announcement object in the list
+  def each(&block)
+    @announcements.each(&block)
+  end
+end

--- a/app/models/announcements.rb
+++ b/app/models/announcements.rb
@@ -2,29 +2,17 @@ class Announcements
   include Enumerable
 
   class << self
-    # Parse from an announcement path file/dir
-    # @param path [#to_s] announcement path
+    # Build a list of announcements by parsing a list of paths
+    # @param paths [#to_s, Array<#to_s>] announcement path or paths
     # @return [Announcements] the parsed announcements
-    def parse(path)
-      path = Pathname.new(path.to_s).expand_path
+    def all(paths = [])
+      paths = Array.wrap(paths).map { |p| Pathname.new(p.to_s).expand_path }
 
-      if path.directory?
-        paths = Pathname.glob(path.join("*.{md,yml}")).sort
-      else
-        paths = [path]
-      end
+      announcements = paths.flat_map do |p|
+        p.directory? ? Pathname.glob(p.join("*.{md,yml}")).sort : p
+      end.map { |p| Announcement.parse(p) }.select(&:valid?)
 
-      new( paths.map {|p| Announcement.parse(p)}.compact.select(&:valid?) )
-    end
-
-    # Build a list of announcements from files
-    # @return [Announcements] all announcements
-    def all
-      if path = Configuration.announcement_path
-        parse(path)
-      else
-        new
-      end
+      new(announcements)
     end
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,11 +52,12 @@
 
   <div class="container content" role="main">
 
-    <% if @announcement %>
-      <div class="alert alert-warning" role="alert">
-        <%=raw markdown(@announcement) %>
+    <% @announcements.each do |announcement| %>
+      <div class="alert alert-<%= announcement.type %>" role="alert">
+        <%= raw markdown(announcement.msg) %>
       </div>
     <% end %>
+
 
     <%= render "layouts/browser_warning" %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -58,7 +58,6 @@
       </div>
     <% end %>
 
-
     <%= render "layouts/browser_warning" %>
 
     <script type="text/coffee-script-template" id="js-alert-danger-template">

--- a/config/configuration_singleton.rb
+++ b/config/configuration_singleton.rb
@@ -42,6 +42,20 @@ class ConfigurationSingleton
     Pathname.new(ENV["OOD_BC_APP_CONFIG_ROOT"] || "/etc/ood/config/apps")
   end
 
+  # The file system path to the announcements
+  # @return [Pathname, nil] announcement path
+  def announcement_path
+    if path = ENV["OOD_ANNOUNCEMENT_PATH"]
+      Pathname.new(path)
+    else
+      [
+        "/etc/ood/config/announcement.md",
+        "/etc/ood/config/announcement.yml",
+        "/etc/ood/config/announcements.d"
+      ].map {|p| Pathname.new(p)}.detect(&:exist?)
+    end
+  end
+
   # Load the dotenv local files first, then the /etc dotenv files and
   # the .env and .env.production or .env.development files.
   #

--- a/config/configuration_singleton.rb
+++ b/config/configuration_singleton.rb
@@ -43,7 +43,7 @@ class ConfigurationSingleton
   end
 
   # The file system path to the announcements
-  # @return [Pathname, nil] announcement path
+  # @return [Pathname, Array<Pathname>] announcement path or paths
   def announcement_path
     if path = ENV["OOD_ANNOUNCEMENT_PATH"]
       Pathname.new(path)
@@ -52,7 +52,7 @@ class ConfigurationSingleton
         "/etc/ood/config/announcement.md",
         "/etc/ood/config/announcement.yml",
         "/etc/ood/config/announcements.d"
-      ].map {|p| Pathname.new(p)}.detect(&:exist?)
+      ].map {|p| Pathname.new(p)}
     end
   end
 

--- a/config/examples/announcements.d/quota.yml
+++ b/config/examples/announcements.d/quota.yml
@@ -1,0 +1,37 @@
+<%-
+  extend ActionView::Helpers::NumberHelper
+
+  threshold = 80
+  cmd = "quota -w"
+  errors = []
+  begin
+    o, e, s = Open3.capture3(cmd)
+    if s.success?
+      o.split("\n").map(&:strip).drop(2).map do |line|
+        disk, *values = line.split(" ")
+        values = values.map(&:to_i)
+        block, max_block, _, files, max_files, _ = values
+        if (block > max_block * threshold / 100)
+          errors << "Within #{threshold}% of limit for **disk space** on `#{disk}` (#{number_to_human_size block * 1024} / #{number_to_human_size max_block * 1024})"
+        end
+        if (files > max_files * threshold / 100)
+          errors << "Within #{threshold}% of limit for **total files** on `#{disk}` (#{number_to_human(files).downcase} files / #{number_to_human(max_files).downcase} files)"
+        end
+      end
+    else
+      raise e
+    end
+  rescue => e
+    Rails.logger.warn "Error parsing quota: #{e.message}"
+    errors = []
+  end
+-%>
+type: warning
+msg: |
+  <%- if errors.any? -%>
+  **Quota warnings:**
+
+  <%- errors.each do |error| -%>
+  - <%= error %>
+  <%- end -%>
+  <%- end -%>

--- a/test/models/announcements_test.rb
+++ b/test/models/announcements_test.rb
@@ -1,0 +1,82 @@
+require 'test_helper'
+
+class AnnouncementsTest < ActiveSupport::TestCase
+  test "should respond to each" do
+    announcements = Announcements.new
+    assert_respond_to announcements, :each
+  end
+
+  test "should return empty list if no valid path" do
+    Configuration.expects(:announcement_path).returns(nil)
+    announcements = Announcements.all
+    assert_equal 0, announcements.count
+  end
+
+  test "should not parse file that doesn't exist" do
+    f = Tempfile.open(["announcement", ".md"])
+    path = f.path
+    f.close(true)
+
+    announcements = Announcements.parse(path)
+    assert_equal 0, announcements.count
+  end
+
+  test "should parse single valid markdown file" do
+    f = Tempfile.open(["announcement", ".md"])
+    f.write %{Test announcement.}
+    f.close
+
+    announcements = Announcements.parse(f.path)
+    assert_equal 1, announcements.count
+    announcement = announcements.first
+    assert_equal :warning, announcement.type
+    assert_equal "Test announcement.", announcement.msg
+  end
+
+  test "should not parse invalid markdown file" do
+    f = Tempfile.open(["announcement", ".md"])
+    f.write %{   \n \n \t    }
+    f.close
+
+    announcements = Announcements.parse(f.path)
+    assert_equal 0, announcements.count
+  end
+
+  test "should parse a valid yaml file" do
+    f = Tempfile.open(["announcement", ".yml"])
+    f.write %{type: success\nmsg: <%= true ? "Test announcement." : "Fail!" %>}
+    f.close
+
+    announcements = Announcements.parse(f.path)
+    assert_equal 1, announcements.count
+    announcement = announcements.first
+    assert_equal :success, announcement.type
+    assert_equal "Test announcement.", announcement.msg
+  end
+
+  test "should not parse invalid yaml file" do
+    f = Tempfile.open(["announcement", ".yml"])
+    f.write %{type: success\nmsg: <%= true ? "null" : "Test announcement." %>}
+    f.close
+
+    announcements = Announcements.parse(f.path)
+    assert_equal 0, announcements.count
+  end
+
+  test "should parse a directory of files" do
+    Dir.mktmpdir("announcements") do |dir|
+      File.open("#{dir}/valid1.md", "w") do |f|
+        f.write %{File 1}
+      end
+      File.open("#{dir}/valid2.yml", "w") do |f|
+        f.write %{msg: "File 2"}
+      end
+      File.open("#{dir}/invalid1.yml", "w") do |f|
+        f.write %{type: danger\nmsg: "<%= true ? "  \n \t " : "Stuff" %>"}
+      end
+
+      announcements = Announcements.parse(dir)
+      assert_equal 2, announcements.count
+    end
+  end
+end


### PR DESCRIPTION
Fixes #306 

Decided to keep code changes to a minimum so cut back on a couple of requirements. I left off ability to place announcement above/below main logo as well as ability to specify what pages announcement appears on. Although these can be added now or in the future.

It provides support for:

- specifying color of announcement with `:type`
- specifying whether announcement appears or not by setting `:msg` to a string or `nil`
- backwards compatible with `/etc/ood/config/announcement.md`, but can support `/etc/ood/config/announcement.yml` or a collection of markdown/yaml announcements in `/etc/ood/config/announcements.d/`

Included an example announcement for quota.