### PR TITLE
Hide sys apps msg if no sys apps

### DIFF
--- a/app/views/apps/featured.html.erb
+++ b/app/views/apps/featured.html.erb
@@ -1,7 +1,9 @@
 <div class="row">
   <div class="col-md-9">
+    <% if @nav_groups.any? %>
     <p class="lead">Cluster access applications are available from the dropdown menus in the navbar above.
     <br>Custom shared apps are available below.</p>
+    <% end %>
     <%= render partial: "catalog_link" %>
   </div>
 </div>


### PR DESCRIPTION
Fixes https://github.com/OSC/ood-dashboard/issues/337

On app sharing dashboard i.e. featured apps dashboard we display a message explaining difference between sys apps and shared apps; this is not required if there are no sys apps.

