### PR TITLE
Add Rake simple task to test job submission on clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added simple Rake task to test cluster job submission.
+  [#358](https://github.com/OSC/ood-dashboard/issues/358)
+
 ### Changed
 - Updated `ood_core` gem to support `Script#native` arrays for the Torque
   adapter.

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -35,17 +35,22 @@ namespace :test do
           break if status.completed?
           sleep 5
         end
-        output = output_path.read
-        if /^#{Regexp.escape(test_string)}$/.match(output)
-          puts "Test for '#{cluster.id}' PASSED!"
+        if output_path.exist?
+          output = output_path.read
+          if /^#{Regexp.escape(test_string)}$/.match(output)
+            puts "Test for '#{cluster.id}' PASSED!"
+          else
+            puts "Couldn't find the test string '#{test_string}' in job output:"
+            puts ""
+            puts output.gsub(/^/, "    ")
+            puts ""
+            puts "Test for '#{cluster.id}' FAILED!"
+          end
+          output_path.rmtree
         else
+          puts "Output file from job does not exist: #{output_path}"
           puts "Test for '#{cluster.id}' FAILED!"
-          puts "Couldn't find the test string '#{test_string}' in job output:"
-          puts ""
-          puts output.gsub(/^/, "    ")
-          puts ""
         end
-        output_path.rmtree
         puts "Finished testing cluster '#{cluster.id}'"
       end
     end

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -1,0 +1,56 @@
+namespace :test do
+  namespace :jobs do
+    WORKDIR = Pathname.new(ENV["WORKDIR"] || "~/test_jobs").expand_path
+
+    directory WORKDIR
+
+    task :all => OodAppkit.clusters.map(&:id)
+
+    OodAppkit.clusters.each do |cluster|
+      desc "Test the cluster: #{cluster.id}"
+      task cluster.id => [:environment, WORKDIR] do
+        unless cluster.job_allow?
+          puts "Skipping '#{cluster.id}' as it doesn't allow job submission."
+          next
+        end
+        puts "Testing cluster '#{cluster.id}'..."
+        test_string = "TEST A B C"
+        output_path = WORKDIR.join("output_#{cluster.id}_#{Time.now.iso8601}.log")
+        script = OodCore::Job::Script.new(
+          job_name: "test_jobs_#{cluster.id}",
+          workdir: WORKDIR,
+          output_path: output_path,
+          wall_time: 60,
+          shell_path: "/bin/bash",
+          content: %{echo "#{test_string}"},
+          native: Shellwords.split(ENV["SUBMIT_ARGS"] || "")
+        )
+        puts "Submitting job..."
+        adapter = cluster.job_adapter
+        job = adapter.submit script
+        puts "Got job id '#{job}'"
+        loop do
+          status = adapter.status(job)
+          puts "Job has status of #{status.to_s}"
+          break if status.completed?
+          sleep 5
+        end
+        output = output_path.read
+        if /^#{Regexp.escape(test_string)}$/.match(output)
+          puts "Test for '#{cluster.id}' PASSED!"
+        else
+          puts "Test for '#{cluster.id}' FAILED!"
+          puts "Couldn't find the test string '#{test_string}' in job output:"
+          puts ""
+          puts output.gsub(/^/, "    ")
+          puts ""
+        end
+        output_path.rmtree
+        puts "Finished testing cluster '#{cluster.id}'"
+      end
+    end
+  end
+
+  desc "Test all clusters"
+  task :jobs => "jobs:all"
+end

--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -81,6 +81,7 @@ class DashboardControllerTest < ActionController::TestCase
 
   test "should create Interactive Apps dropdown" do
     SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys_with_interactive_apps"))
+    OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file("test/fixtures/config/clusters.d"))
 
     get :index
 
@@ -102,36 +103,34 @@ class DashboardControllerTest < ActionController::TestCase
     SysRouter.unstub(:base_path)
   end
 
-  test "should create My Interactive Apps link if Interactive Apps exist" do
+  test "should create My Interactive Apps link if Interactive Apps exist and not developer" do
     SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys_with_interactive_apps"))
+    Configuration.stubs(:app_development_enabled?).returns(false)
+    OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file("test/fixtures/config/clusters.d"))
 
     get :index
     assert_response :success
     assert_select "nav a[href='#{batch_connect_sessions_path}']", 1
-
-    SysRouter.unstub(:base_path)
   end
 
   test "should create My Interactive Apps link if no Interactive Apps and developer" do
-    Configuration.stubs(:app_development_enabled?).returns(true)
     SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys"))
+    Configuration.stubs(:app_development_enabled?).returns(true)
+    OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file("test/fixtures/config/clusters.d"))
 
     get :index
     assert_response :success
     assert_select "nav a[href='#{batch_connect_sessions_path}']", 1
-
-    SysRouter.unstub(:base_path)
   end
 
   test "should not create My Interactive Apps link if no Interactive Apps and not developer" do
-    Configuration.stubs(:app_development_enabled?).returns(false)
     SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys"))
+    Configuration.stubs(:app_development_enabled?).returns(false)
+    OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file("test/fixtures/config/clusters.d"))
 
     get :index
     assert_response :success
     assert_select "nav a[href='#{batch_connect_sessions_path}']", 0
-
-    SysRouter.unstub(:base_path)
   end
 
   test "should not create any empty links" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,4 @@
 ENV['RAILS_ENV'] ||= 'test'
-ENV['OOD_CLUSTERS'] ||= 'test/fixtures/config/clusters.d'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 


### PR DESCRIPTION
Fixes #358 

Available tasks are generated dynamically from available clusters:

```console
$ bin/rake -T test:jobs
rake test:jobs         # Test all clusters
rake test:jobs:oakley  # Test the cluster: oakley
rake test:jobs:owens   # Test the cluster: owens
rake test:jobs:quick   # Test the cluster: quick
rake test:jobs:ruby    # Test the cluster: ruby
```

A sys admin can run it under a *similar* environment as the PUN with:

```console
$ sudo su jnicklas -c 'scl enable rh-ruby22 nodejs010 -- bin/rake test:jobs:oakley RAILS_ENV=production SUBMIT_ARGS="-A PZS0002"'
[sudo] password for jnicklas: 
Testing cluster 'oakley'...
Submitting job...
[2018-04-24 10:15:32 -0400 ]  INFO "execve = [{\"PBS_DEFAULT\"=>\"oak-batch.osc.edu\", \"LD_LIBRARY_PATH\"=>\"/opt/torque/lib64:/opt/rh/v8314/root/usr/lib64:/opt/rh/nodejs010/root/usr/lib64:/opt/rh/rh-ruby22/root/usr/lib64\"}, \"/opt/torque/bin/qsub\", \"-N\", \"test_jobs_oakley\", \"-S\", \"/bin/bash\", \"-o\", \"/users/appl/jnicklas/test_jobs/output_oakley_2018-04-24T10:15:32-04:00.log\", \"-l\", \"walltime=00:01:00\", \"-j\", \"oe\", \"-A\", \"PZS0002\"]"
Got job id '10820525.oak-batch.osc.edu'
Job has status of queued
Job has status of queued
Job has status of queued
Job has status of queued
Job has status of completed
Test for 'oakley' PASSED!
Finished testing cluster 'oakley'
```

Example of a failed test due to incorrect output:

```console
$ sudo su jnicklas -c 'scl enable rh-ruby22 nodejs010 -- bin/rake test:jobs:oakley RAILS_ENV=production SUBMIT_ARGS="-A PZS0002"'
Testing cluster 'oakley'...
Submitting job...
[2018-04-24 10:18:20 -0400 ]  INFO "execve = [{\"PBS_DEFAULT\"=>\"oak-batch.osc.edu\", \"LD_LIBRARY_PATH\"=>\"/opt/torque/lib64:/opt/rh/v8314/root/usr/lib64:/opt/rh/nodejs010/root/usr/lib64:/opt/rh/rh-ruby22/root/usr/lib64\"}, \"/opt/torque/bin/qsub\", \"-N\", \"test_jobs_oakley\", \"-S\", \"/bin/bash\", \"-o\", \"/users/appl/jnicklas/test_jobs/output_oakley_2018-04-24T10:18:20-04:00.log\", \"-l\", \"walltime=00:01:00\", \"-j\", \"oe\", \"-A\", \"PZS0002\"]"
Got job id '10820527.oak-batch.osc.edu'
Job has status of queued
Job has status of queued
Job has status of queued
Job has status of queued
Job has status of queued
Job has status of queued
Job has status of queued
Job has status of running
Job has status of completed
Test for 'oakley' FAILED!
Couldn't find the test string 'TEST A B C' in job output:

    TEST A B C failure
    
    -----------------------
    Resources requested:
    mem=4gb
    nodes=1:ppn=1
    -----------------------
    Resources used:
    cput=00:00:01
    walltime=00:00:03
    mem=0.000 GB
    vmem=0.000 GB
    -----------------------
    Resource units charged (estimate):
    0.000 RUs
    -----------------------

Finished testing cluster 'oakley'
```

Note: Must be run from the root directory of the Dashboard App.