### PR TITLE
Display a human-readable title for paths in Files menu

### DIFF
--- a/app/apps/ood_app.rb
+++ b/app/apps/ood_app.rb
@@ -61,6 +61,7 @@ class OodApp
       file_links = [
         OodAppLink.new(
           title: "Home Directory",
+          subtitle: Dir.home.to_s,
           description: manifest.description,
           url: OodAppkit.files.url(path: Dir.home),
           icon_uri: "fa://home",

--- a/app/apps/ood_app.rb
+++ b/app/apps/ood_app.rb
@@ -58,27 +58,29 @@ class OodApp
   def links
     if role == "files"
       # assumes Home Directory is primary...
-      [
+      file_links = [
         OodAppLink.new(
           title: "Home Directory",
           description: manifest.description,
           url: OodAppkit.files.url(path: Dir.home),
-          icon_uri: icon_uri,
+          icon_uri: "fa://home",
           caption: caption,
           new_tab: true
         )
-      ].concat(
-        OodFilesApp.new.favorite_paths.map do |path|
+      ]
+      OodFilesApp.new.favorite_paths.each { |path, description|
+        file_links.concat([
           OodAppLink.new(
-            title: path.to_s,
+            title: description.to_s,
+            subtitle: path.to_s,
             description: manifest.description,
             url: OodAppkit.files.url(path: path),
             icon_uri: "fa://folder",
             caption: caption,
-            new_tab: true
-          )
-        end
-      )
+            new_tab: true)
+        ])
+      }
+      return file_links
     elsif role == "shell"
       login_clusters = OodCore::Clusters.new(
         OodAppkit.clusters
@@ -246,7 +248,7 @@ class OodApp
   # @return [Boolean] true if Gemfile.lock has specified gem name
   def has_gem?(gemname)
     # FIXME: we want to make this public, test it, and add functionality to make it
-    # work whether the app has a Gemfile.lock or just a Gemfile. 
+    # work whether the app has a Gemfile.lock or just a Gemfile.
     # see ood_app_test.rb
     has_gemfile? && bundler_helper.has_gem?(gemname)
   end

--- a/app/apps/ood_app_link.rb
+++ b/app/apps/ood_app_link.rb
@@ -1,5 +1,6 @@
 class OodAppLink
   attr_reader :title
+  attr_reader :subtitle
   attr_reader :description
   attr_reader :url
   attr_reader :icon_uri
@@ -9,6 +10,7 @@ class OodAppLink
     config = config.to_h.compact.symbolize_keys
 
     @title       = config.fetch(:title, "No title set").to_s
+    @subtitle    = config.fetch(:subtitle, "").to_s
     @description = config.fetch(:description, "").to_s
     @url         = config.fetch(:url, "").to_s
     @icon_uri    = URI(config.fetch(:icon_uri, "fa://gear").to_s)

--- a/app/apps/ood_files_app.rb
+++ b/app/apps/ood_files_app.rb
@@ -1,25 +1,26 @@
 # utility class for dealing with apps that play "files" role
 class OodFilesApp
   class << self
-    # an array of Pathname objects to check for the existence of and access to
-    # should always be []
-    # set in config/initializers/ood.rb
+    # a hash of Pathname objects as keys paired with clarifying descriptions as
+    # the corresponding values
+    # should always be {}
+    # see config/examples/osc/initializers/ood.rb
     attr_accessor :candidate_favorite_paths
   end
-  self.candidate_favorite_paths = []
+  self.candidate_favorite_paths = {}
 
 
   # esure that [] is returned if class variable is not set
   def candidate_favorite_paths
-    self.class.candidate_favorite_paths || []
+    self.class.candidate_favorite_paths || {}
   end
 
   # when showing a link to the file explorer we always show
   # a link to the user's home directory
   # returns an array of other paths provided as shortcuts to the user
   def favorite_paths
-    @favorite_paths ||= candidate_favorite_paths.select {|p|
-      p.directory? && p.readable? && p.executable?
+    @favorite_paths ||= candidate_favorite_paths.select {|path, desc|
+      path.directory? && path.readable? && path.executable?
     }
   end
 end

--- a/app/views/layouts/nav/_group.html.erb
+++ b/app/views/layouts/nav/_group.html.erb
@@ -10,7 +10,7 @@
             <%=
               link_to(
                 link.url.to_s,
-                title: link.title,
+                title: link.description.empty? ? link.title : link.description,
                 target: link.new_tab? ? "_blank" : nil
               ) do
             %>

--- a/app/views/layouts/nav/_group.html.erb
+++ b/app/views/layouts/nav/_group.html.erb
@@ -14,7 +14,7 @@
                 target: link.new_tab? ? "_blank" : nil
               ) do
             %>
-              <%= icon_tag(link.icon_uri) %> <%= link.title %>
+              <%= icon_tag(link.icon_uri) %> <%= link.title %> <%== "<br /><small>#{link.subtitle}</small>" unless link.subtitle.empty? %>
             <% end %>
           </li>
         <% end %>

--- a/config/examples/osc/initializers/ood.rb
+++ b/config/examples/osc/initializers/ood.rb
@@ -1,11 +1,15 @@
 OodFilesApp.candidate_favorite_paths.tap do |paths|
   # add project space directories
   projects = User.new.groups.map(&:name).grep(/^P./)
-  paths.concat projects.map { |p| Pathname.new("/fs/project/#{p}")  }
+  projects.each { |proj|
+    paths[Pathname.new("/fs/project/#{proj}")] = "Project Space"
+  }
 
   # add scratch space directories
-  paths << Pathname.new("/fs/scratch/#{User.new.name}")
-  paths.concat projects.map { |p| Pathname.new("/fs/scratch/#{p}")  }
+  paths[Pathname.new("/fs/scratch/#{User.new.name}")] = "Scratch Space"
+  projects.each { |proj|
+    paths[Pathname.new("/fs/scratch/#{proj}")] = "Scratch Space"
+  }
 end
 
 # uncomment if you want to revert to the old menu


### PR DESCRIPTION
Fixes #156 

I tried to incorporate it into the existing code in the most sensible way. I'm not sure how the <li class="divider"> element got in the menu in the screen clip in #156, but I deemed it too tricky to implement for this occasion. The reason I didn't make a new class like suggested is because this Files menu along with Jobs, Clusters, and Interactive Apps are all treated the same. They use the same Rails partial. They are for presenting the user with all the apps available in /var/www/ood/apps/sys/ in a nice way. The project and scratch spaces only show up in that menu because of a Rails initializer that isn't active when you do an install of the Dashboard straight from GitHub. Maybe we want to treat the Files menu separately?