### PR TITLE
add whitelist mode and set to false by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-###Changed
+### Changed
 - Added whitelist mode to manage categories in the navbar.
   [#295](https://github.com/OSC/ood-dashboard/issues/295)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Changed
+### Added
 - Added whitelist mode to manage categories in the navbar.
   [#295](https://github.com/OSC/ood-dashboard/issues/295)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+###Changed
+- Added whitelist mode to manage categories in the navbar.
+  [#295](https://github.com/OSC/ood-dashboard/issues/295)
 
 ## [1.26.2] - 2018-05-14
 ### Fixed

--- a/app/apps/nav_config.rb
+++ b/app/apps/nav_config.rb
@@ -3,7 +3,7 @@ class NavConfig
     attr_accessor :categories, :categories_whitelist
   end
   self.categories = ["Files", "Jobs", "Clusters", "Interactive Apps"]
-  self.categories_whitelist = true
+  self.categories_whitelist = false
   def self.categories_whitelist?
       self.categories_whitelist
   end

--- a/app/apps/nav_config.rb
+++ b/app/apps/nav_config.rb
@@ -1,6 +1,10 @@
 class NavConfig
   class << self
-    attr_accessor :categories
+    attr_accessor :categories, :categories_whitelist
   end
   self.categories = ["Files", "Jobs", "Clusters", "Interactive Apps"]
+  self.categories_whitelist = true
+  def self.categories_whitelist?
+      self.categories_whitelist
+  end
 end

--- a/app/apps/nav_config.rb
+++ b/app/apps/nav_config.rb
@@ -1,10 +1,8 @@
 class NavConfig
-  class << self
-    attr_accessor :categories, :categories_whitelist
-  end
-  self.categories = ["Files", "Jobs", "Clusters", "Interactive Apps"]
-  self.categories_whitelist = false
-  def self.categories_whitelist?
-      self.categories_whitelist
-  end
+    class << self
+      attr_accessor :categories, :categories_whitelist
+      alias_method :categories_whitelist?, :categories_whitelist
+    end
+    self.categories = ["Files", "Jobs", "Clusters", "Interactive Apps"]
+    self.categories_whitelist = false
 end

--- a/app/apps/ood_app_group.rb
+++ b/app/apps/ood_app_group.rb
@@ -34,15 +34,11 @@ class OodAppGroup
     # only one group per title; this just makes it easy to get the group
     # Hash[ [:title1,:group1], [:title2,:group2]] => {title1: :group1, title2: :group2 }
     h = Hash[groups.map {|g| [g.title, g]}]
-
     titles.map { |t| h.has_key?(t) ? h[t] : nil }.compact
   end
   
   def self.order(titles:[], groups:[])
       h = Hash[groups.map {|g| [g.title, g]}]
-      unselected =[]
-      selected = []
-      titles.each { |t| h.has_key?(t) ? selected.push(h[t]) : unselected.push(h[t]) }
-      selected.concat(unselected.sort)
+      titles.concat(h.keys.sort).uniq.map { |t| h.has_key?(t) ? h[t] : nil }.compact 
   end
 end

--- a/app/apps/ood_app_group.rb
+++ b/app/apps/ood_app_group.rb
@@ -37,14 +37,12 @@ class OodAppGroup
     titles.map { |t| h.has_key?(t) ? h[t] : nil }.compact
   end
   
-  # select a subset of groups by the specified array of titles
-  # maintaining the order specified by the titles array
+  # Append groups not in the specified array in alphabetical order at the end of
+  # subset of groups in the titles array maintaining the order specified by the titles array
   #
-  # append groups not in the  specified array at the end
-  # in alphabetical order
-  #
-  # This way we can get a list of deployed sys apps, then group them by category
-  # then select only the categories we want to display in the menu
+  # This way we can get a list of deployed sys apps, then group them by category,
+  # then display categories in titles array in specific order,
+  # then display other categories in alphabetical order
   def self.order(titles:[], groups:[])
       h = Hash[groups.map {|g| [g.title, g]}]
       titles.concat(h.keys.sort).uniq.map { |t| h.has_key?(t) ? h[t] : nil }.compact 

--- a/app/apps/ood_app_group.rb
+++ b/app/apps/ood_app_group.rb
@@ -37,6 +37,14 @@ class OodAppGroup
     titles.map { |t| h.has_key?(t) ? h[t] : nil }.compact
   end
   
+  # select a subset of groups by the specified array of titles
+  # maintaining the order specified by the titles array
+  #
+  # append groups not in the  specified array at the end
+  # in alphabetical order
+  #
+  # This way we can get a list of deployed sys apps, then group them by category
+  # then select only the categories we want to display in the menu
   def self.order(titles:[], groups:[])
       h = Hash[groups.map {|g| [g.title, g]}]
       titles.concat(h.keys.sort).uniq.map { |t| h.has_key?(t) ? h[t] : nil }.compact 

--- a/app/apps/ood_app_group.rb
+++ b/app/apps/ood_app_group.rb
@@ -37,4 +37,12 @@ class OodAppGroup
 
     titles.map { |t| h.has_key?(t) ? h[t] : nil }.compact
   end
+  
+  def self.order(titles:[], groups:[])
+      h = Hash[groups.map {|g| [g.title, g]}]
+      unselected =[]
+      selected = []
+      titles.each { |t| h.has_key?(t) ? selected.push(h[t]) : unselected.push(h[t]) }
+      selected.concat(unselected.sort)
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,11 @@ class ApplicationController < ActionController::Base
 
   def set_nav_groups
     #TODO: for AweSim, what if we added the shared apps here?
-    @nav_groups = OodAppGroup.select(titles: NavConfig.categories, groups: sys_app_groups)
+    if NavConfig.categories_whitelist?
+        @nav_groups = OodAppGroup.select(titles: NavConfig.categories, groups: sys_app_groups)
+    else
+        @nav_groups = OodAppGroup.order(titles: NavConfig.categories, groups: sys_app_groups)
+    end
   end
 
   def sys_apps

--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -137,7 +137,7 @@ class DashboardControllerTest < ActionController::TestCase
     assert_select "nav a[href='#{batch_connect_sessions_path}']", 0
   end
 
-# gate
+  #test whitelist mode 
   test "should not create app menus if NavConfig.categories is empty and whitelist is enabled" do
     SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys_with_gateway_apps"))
     OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file("test/fixtures/config/clusters.d"))

--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -141,7 +141,7 @@ class DashboardControllerTest < ActionController::TestCase
   test "should not create app menus if NavConfig.categories is empty and whitelist is enabled" do
     SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys_with_gateway_apps"))
     OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file("test/fixtures/config/clusters.d"))
-    NavConfig.stubs(:categories_whitelist).returns(true)
+    NavConfig.stubs(:categories_whitelist?).returns(true)
     NavConfig.stubs(:categories).returns([])
     
     get :index
@@ -152,7 +152,7 @@ class DashboardControllerTest < ActionController::TestCase
   test "should exclude gateway apps if NavConfig.categories is set to default and whitelist is enabled" do
     SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys_with_gateway_apps"))
     OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file("test/fixtures/config/clusters.d"))
-    NavConfig.stubs(:categories_whitelist).returns(true)
+    NavConfig.stubs(:categories_whitelist?).returns(true)
     NavConfig.stubs(:categories).returns(["Files", "Jobs", "Clusters", "Interactive Apps"])
 
     get :index
@@ -163,7 +163,7 @@ class DashboardControllerTest < ActionController::TestCase
   test "should include gateway and System Installed apps in alphabetical order in end if NavConfig.categories is set to default listing and whitelist is disabled" do
     SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys_with_gateway_apps"))
     OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file("test/fixtures/config/clusters.d"))
-    NavConfig.stubs(:categories_whitelist).returns(false)
+    NavConfig.stubs(:categories_whitelist?).returns(false)
     NavConfig.stubs(:categories).returns(["Files", "Jobs", "Clusters", "Interactive Apps"])
     
     get :index
@@ -180,7 +180,7 @@ class DashboardControllerTest < ActionController::TestCase
   test "should include all apps in alphabetical order if NavConfig.categories is set to nil or empty array and whitelist is disabled" do
     SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys_with_gateway_apps"))
     OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file("test/fixtures/config/clusters.d"))
-    NavConfig.stubs(:categories_whitelist).returns(false)
+    NavConfig.stubs(:categories_whitelist?).returns(false)
     NavConfig.stubs(:categories).returns([])
 
     get :index

--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -147,6 +147,8 @@ class DashboardControllerTest < ActionController::TestCase
     get :index
     assert_response :success
     assert_select ".navbar-collapse > .nav li.dropdown[title]", 0
+    NavConfig.unstub(:categories_whitelist?)
+    NavConfig.unstub(:categories)
   end
 
   test "should exclude gateway apps if NavConfig.categories is set to default and whitelist is enabled" do
@@ -158,6 +160,8 @@ class DashboardControllerTest < ActionController::TestCase
     get :index
     assert_response :success
     assert_select ".navbar-collapse > .nav li.dropdown[title='Gateway Apps']", 0
+    NavConfig.unstub(:categories_whitelist?)
+    NavConfig.unstub(:categories)
   end
 
   test "should include gateway and System Installed apps in alphabetical order in end if NavConfig.categories is set to default listing and whitelist is disabled" do
@@ -175,6 +179,8 @@ class DashboardControllerTest < ActionController::TestCase
     assert_select  dropdown_link(4), text: "Interactive Apps"
     assert_select  dropdown_link(5), text: "Gateway Apps"
     assert_select  dropdown_link(6), text: "System Installed Apps"
+    NavConfig.unstub(:categories_whitelist?)
+    NavConfig.unstub(:categories)
   end
 
   test "should include all apps in alphabetical order if NavConfig.categories is set to nil or empty array and whitelist is disabled" do
@@ -192,6 +198,8 @@ class DashboardControllerTest < ActionController::TestCase
     assert_select dropdown_link(4), text: "Interactive Apps"
     assert_select dropdown_link(5), text: "Jobs"
     assert_select dropdown_link(6), text: "System Installed Apps"
+    NavConfig.unstub(:categories_whitelist?)
+    NavConfig.unstub(:categories)
   end
   
   test "should not create any empty links" do

--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -15,6 +15,10 @@ class DashboardControllerTest < ActionController::TestCase
   def dropdown_list(title)
     css_select("li.dropdown[title='#{title}'] ul")
   end
+  
+  def dropdown_link(order)
+    ".navbar-collapse > .nav li.dropdown:nth-of-type(#{order}) a"
+  end
 
   # given a dropdown list, return the list items as an array of strings
   # with symbols for header or divider
@@ -133,6 +137,63 @@ class DashboardControllerTest < ActionController::TestCase
     assert_select "nav a[href='#{batch_connect_sessions_path}']", 0
   end
 
+# gate
+  test "should not create app menus if NavConfig.categories is empty and whitelist is enabled" do
+    SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys_with_gateway_apps"))
+    OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file("test/fixtures/config/clusters.d"))
+    NavConfig.stubs(:categories_whitelist).returns(true)
+    NavConfig.stubs(:categories).returns([])
+    
+    get :index
+    assert_response :success
+    assert_select ".navbar-collapse > .nav li.dropdown[title]", 0
+  end
+
+  test "should exclude gateway apps if NavConfig.categories is set to default and whitelist is enabled" do
+    SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys_with_gateway_apps"))
+    OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file("test/fixtures/config/clusters.d"))
+    NavConfig.stubs(:categories_whitelist).returns(true)
+    NavConfig.stubs(:categories).returns(["Files", "Jobs", "Clusters", "Interactive Apps"])
+
+    get :index
+    assert_response :success
+    assert_select ".navbar-collapse > .nav li.dropdown[title='Gateway Apps']", 0
+  end
+
+  test "should include gateway and System Installed apps in alphabetical order in end if NavConfig.categories is set to default listing and whitelist is disabled" do
+    SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys_with_gateway_apps"))
+    OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file("test/fixtures/config/clusters.d"))
+    NavConfig.stubs(:categories_whitelist).returns(false)
+    NavConfig.stubs(:categories).returns(["Files", "Jobs", "Clusters", "Interactive Apps"])
+    
+    get :index
+    assert_response :success
+    assert_select ".navbar-collapse > .nav li.dropdown[title]", 6
+    assert_select  dropdown_link(1), text: "Files"
+    assert_select  dropdown_link(2), text: "Jobs"
+    assert_select  dropdown_link(3), text: "Clusters"
+    assert_select  dropdown_link(4), text: "Interactive Apps"
+    assert_select  dropdown_link(5), text: "Gateway Apps"
+    assert_select  dropdown_link(6), text: "System Installed Apps"
+  end
+
+  test "should include all apps in alphabetical order if NavConfig.categories is set to nil or empty array and whitelist is disabled" do
+    SysRouter.stubs(:base_path).returns(Rails.root.join("test/fixtures/sys_with_gateway_apps"))
+    OodAppkit.stubs(:clusters).returns(OodCore::Clusters.load_file("test/fixtures/config/clusters.d"))
+    NavConfig.stubs(:categories_whitelist).returns(false)
+    NavConfig.stubs(:categories).returns([])
+
+    get :index
+    assert_response :success
+    assert_select ".navbar-collapse > .nav li.dropdown[title]", 6
+    assert_select dropdown_link(1), text: "Clusters"
+    assert_select dropdown_link(2), text: "Files"
+    assert_select dropdown_link(3), text: "Gateway Apps"
+    assert_select dropdown_link(4), text: "Interactive Apps"
+    assert_select dropdown_link(5), text: "Jobs"
+    assert_select dropdown_link(6), text: "System Installed Apps"
+  end
+  
   test "should not create any empty links" do
     get :index
 

--- a/test/fixtures/sys_with_gateway_apps/activejobs/manifest.yml
+++ b/test/fixtures/sys_with_gateway_apps/activejobs/manifest.yml
@@ -1,0 +1,6 @@
+---
+name: Active Jobs
+category: Jobs
+description: |-
+  View jobs currently running on OSC clusters.
+icon: fa://clock-o

--- a/test/fixtures/sys_with_gateway_apps/bc_desktop/form.yml
+++ b/test/fixtures/sys_with_gateway_apps/bc_desktop/form.yml
@@ -1,0 +1,23 @@
+---
+description: |
+  This app will launch an interactive desktop on one or more compute nodes. You
+  will have full access to the resources these nodes provide. This is analogous
+  to an interctive batch job.
+
+attributes:
+  desktop: "mate"
+  bc_vnc_idle: 0
+  bc_vnc_resolution:
+    required: true
+  node_type: null
+
+form:
+  - bc_vnc_idle
+  - desktop
+  - bc_num_hours
+  - bc_num_slots
+  - node_type
+  - bc_account
+  - bc_queue
+  - bc_vnc_resolution
+  - bc_email_on_started

--- a/test/fixtures/sys_with_gateway_apps/bc_desktop/local/oakley.yml
+++ b/test/fixtures/sys_with_gateway_apps/bc_desktop/local/oakley.yml
@@ -1,0 +1,34 @@
+---
+title: "Oakley Desktop"
+cluster: "oakley"
+attributes:
+  desktop: "gnome"
+  bc_queue: null
+  bc_account:
+    help: "You can leave this blank if **not** in multiple projects."
+  node_type:
+    widget: select
+    label: "Node type"
+    help: |
+      - **any** - (*12 cores*) Chooses anyone of the available Oakley nodes.
+        This reduces the wait time as you have no requirements.
+      - **vis** - (*12 cores*) This node includes an NVIDIA Tesla M2070 GPU
+        with an X server running in the background. This allows for Hardware
+        Rendering with the GPU typically needed for 3D visualization using
+        VirtualGL. There are currently only 128 of these nodes on Oakley.
+      - **gpu** -  (*12 cores*) This node includes an NVIDIA Tesla M2070 GPU
+        allowing for CUDA computations. There are currently only 128 of these
+        nodes on Oakley. These nodes don't start an X server, so visualization
+        with hardware rendering is not possible.
+      - **bigmem** - (*12 cores*) This Oakley node comes with 192GB of
+        available RAM. There are only 8 of these nodes on Oakley.
+      - **hugemem** - (*32 cores*) This Oakley node has 1TB of available RAM as
+        well as 32 cores. There is only 1 of these nodes on Oakley. A
+        reservation may be required to use this node.
+    options:
+      - ["any", ":ppn=12"]
+      - ["vis", ":ppn=12:vis:gpus=1"]
+      - ["gpu", ":ppn=12:gpus=1"]
+      - ["bigmem", ":ppn=12:bigmem"]
+      - ["hugemem", ":ppn=32:hugemem"]
+submit: submit/pbs.yml.erb

--- a/test/fixtures/sys_with_gateway_apps/bc_desktop/manifest.yml
+++ b/test/fixtures/sys_with_gateway_apps/bc_desktop/manifest.yml
@@ -1,0 +1,6 @@
+---
+name: Desktops
+category: Interactive Apps
+subcategory: Desktops
+icon: fa://desktop
+role: batch_connect

--- a/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
+++ b/test/fixtures/sys_with_gateway_apps/bc_jupyter/form.yml
@@ -1,0 +1,29 @@
+---
+title: "Jupyter Notebook"
+cluster: "owens"
+description: |
+  This app will launch a Jupyter Notebook server on one or more Owens nodes.
+attributes:
+  bc_account:
+    help: "You can leave this blank if **not** in multiple projects."
+  node_type:
+    widget: select
+    label: "Node type"
+    help: |
+      - **any** - (*28 cores*) Chooses anyone of the available Owens nodes.
+        This reduces the wait time as you have no requirements.
+      - **gpu** -  (*28 cores*) This node includes an NVIDIA Tesla P100 GPU
+        allowing for CUDA computations. There are currently only 160 of these
+        nodes on Owens.
+      - **hugemem** - (*48 cores*) This Owens node has 1.5TB of available RAM
+        as well as 48 cores. There are 16 of these nodes on Owens.
+    options:
+      - ["any", ":ppn=28"]
+      - ["gpu", ":ppn=28:gpus=1"]
+      - ["hugemem", ":ppn=48:hugemem"]
+form:
+  - bc_num_hours
+  - bc_num_slots
+  - node_type
+  - bc_account
+  - bc_email_on_started

--- a/test/fixtures/sys_with_gateway_apps/bc_jupyter/manifest.yml
+++ b/test/fixtures/sys_with_gateway_apps/bc_jupyter/manifest.yml
@@ -1,0 +1,6 @@
+---
+name: Jupyter
+category: Interactive Apps
+subcategory: Apps
+icon: fa://gear
+role: batch_connect

--- a/test/fixtures/sys_with_gateway_apps/bc_paraview/form.yml
+++ b/test/fixtures/sys_with_gateway_apps/bc_paraview/form.yml
@@ -1,0 +1,15 @@
+---
+title: "Paraview"
+cluster: "quick"
+description: |
+  This app will launch Paraview on an Owens **shared node**. You will be able
+  to interact with Paraview through a VNC session.
+attributes:
+  bc_vnc_resolution:
+    required: true
+  bc_account:
+    help: "You can leave this blank if **not** in multiple projects."
+form:
+  - bc_num_hours
+  - bc_account
+  - bc_vnc_resolution

--- a/test/fixtures/sys_with_gateway_apps/bc_paraview/manifest.yml
+++ b/test/fixtures/sys_with_gateway_apps/bc_paraview/manifest.yml
@@ -1,0 +1,6 @@
+---
+name: Paraview
+category: Interactive Apps
+subcategory: Apps
+icon: fa://gear
+role: batch_connect

--- a/test/fixtures/sys_with_gateway_apps/dashboard/manifest.yml
+++ b/test/fixtures/sys_with_gateway_apps/dashboard/manifest.yml
@@ -1,0 +1,3 @@
+---
+name: Ood Dashboard
+description: stuff

--- a/test/fixtures/sys_with_gateway_apps/file-editor/manifest.yml
+++ b/test/fixtures/sys_with_gateway_apps/file-editor/manifest.yml
@@ -1,0 +1,6 @@
+---
+name: osc-editor
+description: |-
+  A text editor for files on OSC systems
+documentation: |-
+

--- a/test/fixtures/sys_with_gateway_apps/files/manifest.yml
+++ b/test/fixtures/sys_with_gateway_apps/files/manifest.yml
@@ -1,0 +1,6 @@
+---
+name: File Explorer
+description: |-
+category: Files
+icon: fa://folder
+role: files

--- a/test/fixtures/sys_with_gateway_apps/myjobs/manifest.yml
+++ b/test/fixtures/sys_with_gateway_apps/myjobs/manifest.yml
@@ -1,0 +1,4 @@
+---
+name: My Jobs
+category: Jobs
+icon: fa://tasks

--- a/test/fixtures/sys_with_gateway_apps/pseudofun/manifest.yml
+++ b/test/fixtures/sys_with_gateway_apps/pseudofun/manifest.yml
@@ -1,0 +1,13 @@
+---
+name: PseudoFuN
+description: |-
+  PseudoFuN is a computational tool for studying potential functions of
+  pseudogenes in the context of evolution and diseases, developed by the
+  Zhang Lab of Computational Genomics and Proteomics at OSU BMI.
+  PseudoFuN is made of (1) a comprehensive similarity network of known pseudogenes
+  and genes, (2) GO functional annotations of the nodes, (3) as well a sequence
+  query tool that allows the querying of sequences (e.g. novel pseudogene
+  sequence) against the network database.
+category: Gateway Apps
+subcategory: Biomedical Informatics
+icon: fa://search

--- a/test/fixtures/sys_with_gateway_apps/shell/manifest.yml
+++ b/test/fixtures/sys_with_gateway_apps/shell/manifest.yml
@@ -1,0 +1,5 @@
+---
+name: Shell
+category: Clusters
+icon: fa://terminal
+role: shell

--- a/test/fixtures/sys_with_gateway_apps/systemstatus/manifest.yml
+++ b/test/fixtures/sys_with_gateway_apps/systemstatus/manifest.yml
@@ -1,0 +1,6 @@
+---
+name: System Status
+description: |-
+  System Status of OSC Clusters
+category: Clusters
+icon: fa://tachometer


### PR DESCRIPTION
### Default navconfig:
```
  self.categories = ["Files", "Jobs", "Clusters", "Interactive Apps"]
  self.categories_whitelist = false
```

### Views:

- NavConfig.categories is empty and whitelist is enabled results in no app menus being created

![3](https://user-images.githubusercontent.com/22674713/44050055-d1462da6-9f03-11e8-9fc1-b4c7f0063af0.JPG)


- NavConfig.categories is set to default and whitelist is enabled results in app menus excluding gateways app

![2](https://user-images.githubusercontent.com/22674713/44050013-aeb3296a-9f03-11e8-822a-b953d3f21bbc.JPG)

- NavConfig.categories is set to default listing and whitelist is disabled results in app menus including gateways app menu in end

![1](https://user-images.githubusercontent.com/22674713/44049934-7e066e62-9f03-11e8-9fd6-0e46bd5b74c8.JPG)

- NavConfig.categories is set to nil or empty array and whitelist is disabled means that all the possible app menus appear, but in alphabetical order

![4](https://user-images.githubusercontent.com/22674713/44050092-ed6bd4c2-9f03-11e8-8aa5-3da55c2db23f.JPG)
 

### Issues:
1. osc-editor and ood-dashboard are in the System Installed Apps category, so they will be after gateway apps.  Do we want them to stay in the navbar?
2. Do I need to modify categories list according to old description of issue 295?
>
>  Instead of having a default whitelist for the navbar be an ordered list of categories:
> 
> Files, Jobs, Clusters, Interactive Apps
> Lets remove the whitelist by default. If we did that we would order alphabetically, resulting in:
> 
> Clusters, Files, Interactive Apps, Jobs
> Since Files are used the most, we would rename Clusters to Systems, and the default OOD installation would result in this navigation:
> 
> Files, Interactive Apps, Jobs, Systems
> This way, if I add a new app to my default OOD install with the category "Reports" it will immediately appear in the navbar, without any modification in an initializer to specify the whitelist or change the order:
> 
> Files, Interactive Apps, Jobs, Reports, Systems
> For OSC, we could still use our whitelist to limit what drop downs appear (so if we just want Files, Interactive Apps, Jobs, Systems in the top menu, and All Apps to access other apps in other categories in the future).
> 
> This seems like a small change that could make custom app deployment easier at other centers.


fix #295 