### PR TITLE
Log a request whenever user launches OSC Connect

### DIFF
--- a/app/views/batch_connect/sessions/connections/_native_vnc.html.erb
+++ b/app/views/batch_connect/sessions/connections/_native_vnc.html.erb
@@ -10,7 +10,7 @@
       Launch <strong>OSC Connect</strong>
     </li>
     <li>
-      Click - <%= link_to "osc://:#{connect.password}@#{connect.host}:#{connect.port}", "osc://:#{connect.password}@#{connect.host}:#{connect.port}" %>
+      Click - <%= link_to "osc://:#{connect.password}@#{connect.host}:#{connect.port}", "osc://:#{connect.password}@#{connect.host}:#{connect.port}", onclick: "$.get('" + analytics_path(type: "launch_osc_connect") + "');" %>
     </li>
   </ol>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,9 @@ Rails.application.routes.draw do
   get "dashboard/index"
   get "logout" => "dashboard#logout"
 
+  # analytics request appears in the access logs and google analytics
+  get "analytics/:type" => proc { [204, {}, ['']] }, as: "analytics"
+
 
   get "apps/show/:name(/:type(/:owner))" => "apps#show", as: "app", defaults: { type: "sys" }
   get "apps/icon/:name(/:type(/:owner))" => "apps#icon", as: "app_icon", defaults: { type: "sys" }


### PR DESCRIPTION
Add a /analytics/xxxx route so we can make arbitrary ajax requests
to log user activity .this is a simple poor-man's way of having
some actions appear in searchable logs

on click of the osc connect link, do a get request to this analytics URL

since this opens a registered URL scheme, similar to file downloads,
this will not result in unloading the current page so JavaScript will
not stop running; thus both the default event handling for links can
execute while our logging ajax request can execute