### PR TITLE
Hide apps without categories from nav

### DIFF
--- a/app/apps/ood_app.rb
+++ b/app/apps/ood_app.rb
@@ -29,6 +29,10 @@ class OodApp
     batch_connect_app? && batch_connect.sub_app_list.none?(&:valid?)
   end
 
+  def should_appear_in_nav?
+    manifest? && ! (invalid_batch_connect_app? || category.empty?)
+  end
+
   def initialize(router)
     @router = router
   end
@@ -151,7 +155,11 @@ class OodApp
   end
 
   def category
-    manifest.category.empty? ? router.category : manifest.category
+    if (! router.category.empty?) && manifest.category.empty?
+      router.category
+    else
+      manifest.category
+    end
   end
 
   def subcategory

--- a/app/apps/sys_router.rb
+++ b/app/apps/sys_router.rb
@@ -45,7 +45,7 @@ class SysRouter
   end
 
   def category
-    "System Installed Apps"
+    ""
   end
 
   def url

--- a/app/apps/usr_router.rb
+++ b/app/apps/usr_router.rb
@@ -12,7 +12,11 @@ class UsrRouter
   #
   # @return [String] human readable owner string
   def caption
-    "Shared by #{owner_title} (#{owner})"
+    if owner_title == owner
+      "Shared by #{owner}"
+    else
+      "Shared by #{owner_title} (#{owner})"
+    end
   end
 
   def category
@@ -20,7 +24,11 @@ class UsrRouter
   end
 
   def owner_title
+    return @owner_title if defined?(@owner_title)
+
     @owner_title ||= (Etc.getpwnam(owner).gecos || owner)
+  rescue
+    @owner_title = owner
   end
 
   # Get array of all apps from specified owners

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,15 +31,15 @@ class ApplicationController < ActionController::Base
   end
 
   def nav_sys_apps
-    sys_apps.select(&:manifest?).reject(&:invalid_batch_connect_app?)
+    sys_apps.select(&:should_appear_in_nav?)
   end
 
   def nav_dev_apps
-    dev_apps.select(&:manifest?).reject(&:invalid_batch_connect_app?)
+    dev_apps.select(&:should_appear_in_nav?)
   end
 
   def nav_usr_apps
-    usr_apps.select(&:manifest?).reject(&:invalid_batch_connect_app?)
+    usr_apps.select(&:should_appear_in_nav?)
   end
 
   def sys_app_groups

--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -4,10 +4,7 @@ class AppsController < ApplicationController
 
   def index
     @core_app_groups = OodAppGroup.select(titles: %w(Files Jobs Clusters), groups: sys_app_groups)
-    # FIXME: currenlty instead of displaying all apps, only display Gateway and Interactive for now;
-    # long term this is not a good solution!
-    # @app_groups = sys_app_groups.select {|g| ! %w(Files Jobs Clusters).include?(g.title) }
-    @app_groups = OodAppGroup.select(titles: ['Interactive Apps', 'Gateway Apps'], groups: sys_app_groups)
+    @app_groups = sys_app_groups.select {|g| ! %w(Files Jobs Clusters).include?(g.title) }
   end
 
   def featured

--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -7,11 +7,6 @@ class DashboardControllerTest < ActionController::TestCase
     OodFilesApp.any_instance.stubs(:favorite_paths).returns([Pathname.new("/fs/scratch/efranz")])
   end
 
-  def teardown
-    SysRouter.unstub(:base_path)
-    OodFilesApp.any_instance.unstub(:favorite_paths)
-  end
-
   def dropdown_list(title)
     css_select("li.dropdown[title='#{title}'] ul")
   end
@@ -103,8 +98,6 @@ class DashboardControllerTest < ActionController::TestCase
     assert_select dd, "li a", "Oakley Desktop" do |link|
       assert_equal "/batch_connect/sys/bc_desktop/oakley/session_contexts/new", link.first['href'], "Desktops link is incorrect"
     end
-
-    SysRouter.unstub(:base_path)
   end
 
   test "should create My Interactive Apps link if Interactive Apps exist and not developer" do
@@ -146,8 +139,6 @@ class DashboardControllerTest < ActionController::TestCase
     get :index
     assert_response :success
     assert_select ".navbar-collapse > .nav li.dropdown[title]", 0
-    NavConfig.unstub(:categories_whitelist?)
-    NavConfig.unstub(:categories)
   end
 
   test "should exclude gateway apps if NavConfig.categories is set to default and whitelist is enabled" do
@@ -159,8 +150,6 @@ class DashboardControllerTest < ActionController::TestCase
     get :index
     assert_response :success
     assert_select ".navbar-collapse > .nav li.dropdown[title='Gateway Apps']", 0
-    NavConfig.unstub(:categories_whitelist?)
-    NavConfig.unstub(:categories)
   end
 
   test "uses NavConfig.categories as sort order if whitelist is false" do
@@ -177,9 +166,6 @@ class DashboardControllerTest < ActionController::TestCase
     assert_select  dropdown_link(3), text: "Clusters"
     assert_select  dropdown_link(4), text: "Interactive Apps"
     assert_select  dropdown_link(5), text: "Gateway Apps"
-
-    NavConfig.unstub(:categories_whitelist?)
-    NavConfig.unstub(:categories)
   end
 
   test "verify default values for NavConfig" do
@@ -201,8 +187,6 @@ class DashboardControllerTest < ActionController::TestCase
     assert_select dropdown_link(3), text: "Gateway Apps"
     assert_select dropdown_link(4), text: "Interactive Apps"
     assert_select dropdown_link(5), text: "Jobs"
-    NavConfig.unstub(:categories_whitelist?)
-    NavConfig.unstub(:categories)
   end
 
   test "apps with no category should not appear in menu" do

--- a/test/models/app_router_test.rb
+++ b/test/models/app_router_test.rb
@@ -48,6 +48,10 @@ class AppRouterTest < ActiveSupport::TestCase
     end
   end
 
+  test "UsrRouter.caption when user is a group (or non-existance user)" do
+    assert_equal "Shared by PZS0714", UsrRouter.new('foo', 'PZS0714').caption
+  end
+
   test "DevRouter.apps should only apps that have periods in directory name" do
     Dir.mktmpdir "apps" do |dir|
       dir = Pathname.new(dir)

--- a/test/models/ood_app_test.rb
+++ b/test/models/ood_app_test.rb
@@ -75,4 +75,28 @@ class OodAppTest < ActiveSupport::TestCase
       refute OodApp.new(PathRouter.new(app_dir)).backup?
     end
   end
+
+  test "sys app with empty category should be hidden from nav" do
+    Dir.mktmpdir "apps" do |dir|
+      dir = Pathname.new(dir)
+      SysRouter.stubs(:base_path).returns(dir)
+
+      app_dir = dir.join("app").tap { |p| p.mkdir }
+      app_dir.join("manifest.yml").write("---\nname: Ood Dashboard\ndescription: stuff")
+
+      refute OodApp.new(SysRouter.new(app_dir.basename.to_s)).should_appear_in_nav?
+    end
+  end
+
+  test "sys app with category should appear in nav" do
+    Dir.mktmpdir "apps" do |dir|
+      dir = Pathname.new(dir)
+      SysRouter.stubs(:base_path).returns(dir)
+
+      app_dir = dir.join("app").tap { |p| p.mkdir }
+      app_dir.join("manifest.yml").write("---\nname: Jobs\ncategory: Jobs")
+
+      assert OodApp.new(SysRouter.new(app_dir.basename.to_s)).should_appear_in_nav?
+    end
+  end
 end


### PR DESCRIPTION
This PR has four fixes.

1. With recent change via https://github.com/OSC/ood-dashboard/pull/385 all apps display in menu by default. Even in this case, the dashboard and file editor should not display. The solution is to hide all apps that don't set the category (i.e. it is an empty string). Only for sys apps is the default category (the `router#category`) set to an empty string. bd53b6e1a465eac24cf29bf4370e75e2bf758daf
2. Remove unstub calls which are redundant as Mocha calls unstub all in teardown.
3. Now that we properly filter out apps that do not have a category set, we don't need the arbitrary hardcoded filter for the "all apps" index page (this page up to this point has been an undocumented feature)
4. Fix crash on UsrRouter when dealing with usr apps owned by groups or non-users i.e. the Shiny apps project