### PR TITLE
Improve time reporting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ gem 'rails_12factor', group: :production
 gem 'mocha', '~> 1.1', group: :test
 gem "spring", group: :test
 gem 'autoprefixer-rails', '~> 8.4'
+gem 'dotiw'
 
 # OOD specific gems
 gem 'ood_support', '~> 0.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,9 @@ GEM
     dotenv-rails (2.5.0)
       dotenv (= 2.5.0)
       railties (>= 3.2, < 6.0)
+    dotiw (4.0.1)
+      actionpack (>= 4)
+      i18n
     erubis (2.7.0)
     execjs (2.7.0)
     ffi (1.9.25)
@@ -199,6 +202,7 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   data-confirm-modal (~> 1.2)
   dotenv-rails (~> 2.0)
+  dotiw
   font-awesome-sass (= 5.0.9)
   jbuilder (~> 2.0)
   jquery-datatables-rails (~> 3.4)

--- a/app/helpers/batch_connect/sessions_helper.rb
+++ b/app/helpers/batch_connect/sessions_helper.rb
@@ -65,17 +65,17 @@ module BatchConnect::SessionsHelper
         if time_limit && time_used
           concat content_tag(:strong, "Time Remaining:")
           concat " "
-          concat distance_of_time_in_words(time_limit - time_used)
+          concat distance_of_time_in_words(time_limit - time_used, 0, false, :only => [:minutes, :hours], :accumulate_on => :hours)
         elsif time_used
           concat content_tag(:strong, "Time Used:")
           concat " "
-          concat distance_of_time_in_words(time_used)
+          concat distance_of_time_in_words(time_used, 0, false, :only => [:minutes, :hours], :accumulate_on => :hours)
         end
       else  # not starting or running
         if time_limit
           concat content_tag(:strong, "Time Requested:")
           concat " "
-          concat pluralize(time_limit / 3600, "hour")
+          concat distance_of_time_in_words(time_limit, 0, false, :only => [:minutes, :hours], :accumulate_on => :hours)
         end
       end
     end


### PR DESCRIPTION
Overrides the Rails `distance_of_time_in_words` with the [`dotiw` gem](https://github.com/radar/distance_of_time_in_words). This gives us the ability to report exact time diffs in words accumulating on the type we want. So two days of compute renders as 48 hours. 3600 seconds renders as 1 hour instead of about 1 hour. Due to the imprecision in our setup we are not reporting on seconds. `dotiw` provides backwards compatible functionality using the :vague keyword if we need that elsewhere in the application.

Fixes #421.