### PR TITLE
iHPC apps to submit to multiple clusters

### DIFF
--- a/app/controllers/batch_connect/session_contexts_controller.rb
+++ b/app/controllers/batch_connect/session_contexts_controller.rb
@@ -23,19 +23,21 @@ class BatchConnect::SessionContextsController < ApplicationController
   # POST /batch_connect/<app_token>/session_contexts.json
   def create
     set_app
-    set_render_format
     set_session_context
+    set_specified_cluster
 
     # Read in context from form parameters
-    @session_context.attributes = session_contexts_param
+    @session_context.attributes = session_contexts_params
 
     @session = BatchConnect::Session.new
     respond_to do |format|
-      if @session.save(app: @app, context: @session_context, format: @render_format)
+      if @cluster && @session.save(app: @app, context: @session_context, format: @cluster.job_config[:adapter], cluster_id: @cluster.id)
         cache_file.write(@session_context.to_json)  # save context to cache file
         format.html { redirect_to batch_connect_sessions_url, notice: 'Session was successfully created.' }
         format.json { head :no_content }
       else
+        @session.errors.add(:base, :cluster_not_specified, "A valid cluster to submit to has not been specified.") unless @cluster
+
         format.html do
           set_app_groups
           render :new
@@ -46,6 +48,17 @@ class BatchConnect::SessionContextsController < ApplicationController
   end
 
   private
+
+    def set_specified_cluster
+      permitted_params = session_contexts_params
+
+      if @app.cluster_dependencies.one?
+        @cluster = @app.cluster_dependencies.first
+      elsif @app.cluster_dependencies.any? && permitted_params[:batch_connect_session_context] && permitted_params[:batch_connect_session_context][:cluster]
+        cluster = @app.cluster_dependencies.find { |cluster| cluster.id == permitted_params[:batch_connect_session_context][:cluster] }
+      end
+    end
+
     # Set the app from the token
     def set_app
       @app = BatchConnect::App.from_token params[:token]
@@ -63,13 +76,36 @@ class BatchConnect::SessionContextsController < ApplicationController
       @session_context = @app.build_session_context
     end
 
-    # Set the rendering format for displaying attributes
+
     def set_render_format
-      @render_format = @app.cluster.job_config[:adapter] if @app.cluster
+      adapters = @app.cluster_dependencies.map { |cluster|
+        cluster.job_config[:adapter]
+      }.compact.uniq
+
+      # FIXME: not sure if we want to write a warning or display a message
+      # seems like you could write custom JavaScript to address the potential
+      # prbblems, and that we would only want to display, perhaps in the help
+      # text of a smart attribute that requires a specific format to display
+      # correctly
+      #
+      # a better solution might be to have render_format be an array of formats
+      # and each smart attribute handle problematic input appropriately
+      #
+      # @render_format and @render_formats, for example, as separate arguments
+      #
+      # if(adapters.count > 1)
+      #   logger.warn "Displaying form with cluster dependency list of multiple adapters that this user can submit jobs to"
+      # elsif adapters.count == 0
+      #   logger.warn "Displaying form with no valid cluster depenenecy specified that this user can submit jobs to"
+      # end
+
+      @render_format = adapters.first
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.
-    def session_contexts_param
+    def session_contexts_params
+      # FIXME: this may cause problems too - it prevents sending in the web
+      # form any form "attribute" that is not specified as an attribute in the yaml file
       params.require(:batch_connect_session_context).permit(@session_context.attributes.keys)
     end
 

--- a/app/models/batch_connect/app.rb
+++ b/app/models/batch_connect/app.rb
@@ -102,37 +102,73 @@ module BatchConnect
       ood_app.manifest.description
     end
 
-    # Cluster id the batch connect app uses
-    # @return [String, nil] cluster id used by app
-    def cluster_id
-      form_config.fetch(:cluster, nil)
+    # The clusters that are available
+    def clusters
+      OodAppkit.clusters
     end
 
-    # The cluster that the batch connect app uses
-    # @return [OodCore::Cluster, nil] cluster that app uses
-    def cluster
-      OodAppkit.clusters[cluster_id] if cluster_id
+    # The clusters that the batch connect app uses
+    # invalid cluster ids are ignored
+    # @return [Array<OodCore::Cluster>] clusters that app uses
+    def cluster_dependencies
+      all_cluster_dependencies.select(&:job_allow?)
+    end
+
+    def all_cluster_dependencies
+      cluster_ids.map {|cluster_id| clusters[cluster_id] }.compact
+    end
+
+    # The ids of clusters that the batch connect app declares it uses
+    # @return [Array<String>] array of ids of clusters that app declares it uses
+    def cluster_ids
+      Array.wrap(form_config.fetch(:cluster, nil)).compact.map(&:to_sym)
     end
 
     # Whether this is a valid app the user can use
+    #
+    # An app is valid if:
+    #
+    # 1. The form config exists
+    # 2. If any clusters that are declared, the user has access to at least one
+    #
     # @return [Boolean] whether valid app
     def valid?
-      (! form_config.empty?) && cluster && cluster.job_allow?
+      valid_form_config? && valid_cluster_ids? && declared_clusters_authorized?
+    end
+
+    # @return [Boolean] true if form config exists
+    def valid_form_config?
+      ! form_config.empty?
+    end
+
+    # FIXME: There is no test coverage for this
+    #        This method would be irrelevant if you had a NullCluster object
+    # @return [Boolean] true if all declared cluster ids are valid
+    def valid_cluster_ids?
+      cluster_ids.all? { |cluster_id|  clusters.include?(cluster_id) }
+    end
+
+    # FIXME: there is no test coverage for this
+    # @return [Boolean] true if no declared clusters or at least one accessible declared cluster
+    def declared_clusters_authorized?
+      if all_cluster_dependencies.any?
+        cluster_dependencies.any?
+      else
+        true
+      end
     end
 
     # The reason why this app may or may not be valid
     # @return [String] reason why not valid
     def validation_reason
-      return @validation_reason if @validation_reason
-
-      if !cluster_id
-        "This app does not specify a cluster."
-      elsif !cluster
+      if @validation_reason
+        @validation_reason
+      elsif !valid_cluster_ids?
         "This app requires a cluster that does not exist."
-      elsif !cluster.job_allow?
+      elsif !declared_clusters_authorized?
         "You do not have access to use this app."
       else
-        ""
+        "There is a problem with this app."
       end
     end
 

--- a/app/models/batch_connect/session.rb
+++ b/app/models/batch_connect/session.rb
@@ -133,10 +133,11 @@ module BatchConnect
     # @param app [BatchConnect::App] batch connect app
     # @param context [BatchConnect::SessionContext] context used for session
     # @param format [String] format used when rendering template
+    # @param cluster_id [String] cluster to submit to
     # @return [Boolean] whether saved successfully
-    def save(app:, context:, format: nil)
+    def save(app:, context:, format: nil, cluster_id: nil)
       self.id         = SecureRandom.uuid
-      self.cluster_id = app.cluster_id
+      self.cluster_id = cluster_id
       self.token      = app.token
       self.title      = app.title
       self.view       = app.session_view

--- a/test/models/batch_connect/app_test.rb
+++ b/test/models/batch_connect/app_test.rb
@@ -1,14 +1,55 @@
 require 'test_helper'
 
 class BatchConnect::AppTest < ActiveSupport::TestCase
-  test "app with malformed form.yml" do
+
+  def with_batch_connect_yaml(yaml)
     Dir.mktmpdir { |dir|
       r = PathRouter.new(dir)
-      r.path.join("form.yml").write("--x-\nnot a valid form yaml")
+      r.path.join("form.yml.erb").write(yaml)
 
       app = BatchConnect::App.new(router: r)
-      assert ! app.valid?
+
+      yield app, Pathname.new(dir)
     }
+  end
+
+  test "app with malformed form.yml" do
+    with_batch_connect_yaml("--x-\nnot a valid form yaml") do |app, app_path|
+      refute app.valid?
+    end
+  end
+
+  test "form.yml.erb can use __FILE__" do
+    with_batch_connect_yaml("---\ntitle: <%= File.expand_path(File.dirname(__FILE__)) %>") do |app, app_path|
+      assert_equal app_path.to_s, app.title, "When rendering form.yml.erb __FILE__ doesn't return correct value"
+    end
+  end
+
+  test "multiple cluster dependencies" do
+    BatchConnect::App.any_instance.stubs(:clusters).returns(OodCore::Clusters.new([
+       OodCore::Cluster.new({id: 'owens', job: {adapter: 'slurm'}}),
+       OodCore::Cluster.new({id: 'pitzer', job: {adapter: 'slurm'}}),
+       OodCore::Cluster.new({id: 'cluster_without_jobs'}),
+    ]))
+
+    with_batch_connect_yaml("---\ncluster: [owens, pitzer, bad_cluster, cluster_without_jobs]") do |app, app_path|
+      assert_equal [:owens, :pitzer, :bad_cluster, :cluster_without_jobs], app.cluster_ids
+      refute app.valid_cluster_ids?, ":bad_cluster should be recognized as an invalid cluster id"
+      assert_equal [:owens, :pitzer], app.cluster_dependencies.map(&:id)
+      assert_equal [["Owens", "owens"], ["Pitzer", "pitzer"]], app.default_cluster_attribute_options[:options]
+    end
+  end
+
+  test "one cluster dependency" do
+    BatchConnect::App.any_instance.stubs(:clusters).returns(OodCore::Clusters.new([
+       OodCore::Cluster.new({id: 'owens', job: {adapter: 'slurm'}}),
+       OodCore::Cluster.new({id: 'pitzer', job: {adapter: 'slurm'}})
+    ]))
+
+    with_batch_connect_yaml("---\ncluster: owens") do |app, app_path|
+      assert_equal [:owens], app.cluster_ids
+      assert_equal [:owens], app.cluster_dependencies.map(&:id)
+    end
   end
 
   test "missing app handled gracefully" do
@@ -29,15 +70,6 @@ class BatchConnect::AppTest < ActiveSupport::TestCase
     }
   end
 
-  test "form.yml.erb can use __FILE__" do
-    Dir.mktmpdir { |dir|
-      r = PathRouter.new(dir)
-      r.path.join("form.yml.erb").write("---\ntitle: <%= File.expand_path(File.dirname(__FILE__)) %>")
-
-      app = BatchConnect::App.new(router: r)
-      assert_equal dir, app.title, "When rendering form.yml.erb __FILE__ doesn't return correct value"
-    }
-  end
 
   test "sub_apps_list doesn't crash when local directory inaccessible" do
     begin
@@ -62,4 +94,5 @@ class BatchConnect::AppTest < ActiveSupport::TestCase
       appdir.rmtree
     end
   end
+
 end


### PR DESCRIPTION
Client side:

1. if there is only one depdendent cluster the user can submit jobs to, that adapter is used for the "format" for client side rendering (i.e. 'format' for the bc_* attributes like bc_num_slots)
2. if there are multiple clusters of same adapter, that is used for "format" for client side rendering
3. if there are multiple clusters of different adapters, the first in the list is used (BUG - not currently fixed nor warned - also rarer edge case)

Server side:

1. server side if there is only one depdendent cluster the user can submit jobs to, that adapter is used for "format" and that id is used for cluster_id
2. server side if there is multiple dependent clusters available, and the id of one is specified in the web form submission paramter name "batch_connect_session_context[cluster]" that is used for adapter "format" and cluster_id
3. server side, if there is multiple dependent clusters available, and one is not specified, or if there are no dependent clusters available, an error is thrown