### PR TITLE
Update default logout wording fixes #420

### DIFF
--- a/app/views/dashboard/logout.html.erb
+++ b/app/views/dashboard/logout.html.erb
@@ -1,5 +1,15 @@
 <!-- For basic authentication, we ask the user to close their browser -->
 <div class="jumbotron">
-  <h2>Log Out</h2>
-  <p class="lead">Please close your browser to log out. If after reopening your browser you are still logged in, please clear your cookies.</p>
+  <h2>You are not yet logged out</h2>
+  <p class="lead"><strong>You must completely quit your browser</strong> in order
+    for "logout" to occur. If after reopening your browser you are still logged
+    in, please clear your cookies. If you are on a Chromebook or Chromebox, you
+    will need to reboot your device in order to "quit the browser" and thus "logout".
+  <p>
+</div>
+
+<div class="alert alert-info"><strong>Tip:
+  Using a "private browsing mode"</strong> window while using OnDemand is a great
+  way to handle "auto-logout", as closing your browser window will remove all
+  associated cookies and session information.
 </div>


### PR DESCRIPTION
1. make the default logout message more clear as to the actions users must take to completely logout
2. address edgecase when using Chromebook
3. suggest using private browsing mode

Fixes https://github.com/OSC/ood-dashboard/issues/420

![screen 2018-12-12 at 3 01 55 pm](https://user-images.githubusercontent.com/512333/49895631-eccafc80-fe1e-11e8-9f87-aad895790c79.png)
