### PR TITLE
Use new dev apps env var OOD_DEV_APPS_ROOT

### DIFF
--- a/app/apps/dev_router.rb
+++ b/app/apps/dev_router.rb
@@ -26,7 +26,7 @@ class DevRouter
   end
 
   def self.base_path(owner: OodSupport::Process.user.name)
-    Pathname.new "#{Dir.home(owner)}/#{ENV['OOD_PORTAL'] || "ondemand"}/dev"
+    Configuration.dev_apps_root_path
   end
 
   def base_path

--- a/config/configuration_singleton.rb
+++ b/config/configuration_singleton.rb
@@ -87,9 +87,13 @@ class ConfigurationSingleton
     Dotenv.load(*dotenv_files)
   end
 
+  def dev_apps_root_path
+    Pathname.new(ENV["OOD_DEV_APPS_ROOT"] || "/dev/null")
+  end
+
   def app_development_enabled?
     return @app_development_enabled if defined? @app_development_enabled
-    to_bool(ENV['OOD_APP_DEVELOPMENT'] || DevRouter.base_path.exist?)
+    to_bool(ENV['OOD_APP_DEVELOPMENT'] || DevRouter.base_path.directory?)
   end
   alias_method :app_development_enabled, :app_development_enabled?
 

--- a/test/integration/products_test.rb
+++ b/test/integration/products_test.rb
@@ -2,12 +2,13 @@ require 'test_helper'
 
 class ProductsTest < ActionDispatch::IntegrationTest
   test "sandbox_apps_accessible_if_app_development_enabled" do
-    Configuration.stubs(:app_development_enabled?).returns(true)
+    Dir.mktmpdir do |dir|
+      Configuration.stubs(:app_development_enabled?).returns(true)
+      Configuration.stubs(:dev_apps_root_path).returns(Pathname.new(dir))
 
-    get "/admin/dev/products"
-    assert_response :success
-
-    Configuration.unstub(:app_development_enabled?)
+      get "/admin/dev/products"
+      assert_response :success
+    end
   end
 
   test "sandbox_apps_not_accessible_if_app_development_disabled" do
@@ -16,7 +17,5 @@ class ProductsTest < ActionDispatch::IntegrationTest
     assert_raises(ActionController::RoutingError) do
       get "/admin/dev/products"
     end
-
-    Configuration.unstub(:app_development_enabled?)
   end
 end


### PR DESCRIPTION
dev apps base path is now to be defined in OOD_DEV_APPS_ROOT

nginx_stage will set this to whatever is configured in nginx_stage.yml
config

this ensures that default dev app setup in OOD 1.4 will work without requiring
extra steps like adding this code to an initializer:

    Configuration.app_development_enabled = File.directory? "/var/www/ood/apps/dev/#{OodSupport::Process.user.name}/gateway"