### PR TITLE
Fix displaying batch connect launch btn

### DIFF
--- a/app/apps/ood_app.rb
+++ b/app/apps/ood_app.rb
@@ -114,16 +114,7 @@ class OodApp
         end.sort_by { |lnk| lnk.title }
       end
     elsif role == "batch_connect"
-      batch_connect.sub_app_list.select(&:valid?).map do |sub_app|
-        OodAppLink.new(
-          title: sub_app.title,
-          description: sub_app.description,
-          url: new_batch_connect_session_context_path(token: sub_app.token),
-          icon_uri: icon_uri,
-          caption: caption,
-          new_tab: false
-        )
-      end
+      batch_connect.sub_app_list.select(&:valid?).map(&:link)
     else
       [
         OodAppLink.new(
@@ -135,6 +126,17 @@ class OodApp
           new_tab: true
         )
       ]
+    end
+  end
+
+  def links_without_validation
+    # hack - but at least this hack is in a method next to the method it is
+    # coupled with and this prevents control coupling from the outside by doing
+    # something atrocious like links(validate: false)
+    if role == "batch_connect"
+      batch_connect.sub_app_list.map(&:link)
+    else
+      links
     end
   end
 

--- a/app/models/batch_connect/app.rb
+++ b/app/models/batch_connect/app.rb
@@ -102,6 +102,18 @@ module BatchConnect
       ood_app.manifest.description
     end
 
+    def link
+      OodAppLink.new(
+        # FIXME: better to use default_title and "" description
+        title: title,
+        description: description,
+        url: Rails.application.routes.url_helpers.new_batch_connect_session_context_path(token: token),
+        icon_uri: ood_app.icon_uri,
+        caption: ood_app.caption,
+        new_tab: false
+      )
+    end
+
     # Cluster id the batch connect app uses
     # @return [String, nil] cluster id used by app
     def cluster_id

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -25,7 +25,7 @@
   </td>
   <td>
     <div class="btn-group-vertical btn-block">
-      <%- product.app.links.each do |link| -%>
+      <%- product.app.links_without_validation.each do |link| -%>
         <%=
           link_to(
             "Launch #{link.title}",

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -19,7 +19,7 @@
   </div><!-- /.col-md-2 -->
   <div class="col-md-6 col-sm-10 col-xs-12">
     <div class="btn-group-vertical">
-      <%- @product.app.links.each do |link| -%>
+      <%- @product.app.links_without_validation.each do |link| -%>
         <%=
           link_to(
             "Launch #{link.title}",


### PR DESCRIPTION
in the developer views, the batch connect
launch buttons would not appear if the batch connect app was
not a "valid" app - which is the case when you start developing
a new app that doesn't specify a required cluster, for example, or
if you write some code that breaks the erb rendering

this ensures that the launch buttons always display in the developer views