### PR TITLE
Handle invalid limit in quota

### DIFF
--- a/app/models/quota.rb
+++ b/app/models/quota.rb
@@ -99,7 +99,11 @@ class Quota
   end
 
   def sufficient?(threshold: 0.95)
-    @total_usage < threshold * @limit
+    if valid?
+      @total_usage < threshold * @limit
+    else
+      true
+    end
   end
 
   def insufficient?(threshold: 0.95)
@@ -109,13 +113,26 @@ class Quota
   # Percent of user resource units used for this volume
   # @return [Integer] percent user usage
   def percent_user_usage
-    @user_usage * 100 / @limit
+    if valid?
+      @user_usage * 100 / @limit
+    else
+      0
+    end
   end
 
   # Percent of total resource units used for this volume
   # @return [Integer] percent total block usage
   def percent_total_usage
-    @total_usage * 100 / @limit
+    if valid?
+      @total_usage * 100 / @limit
+    else
+      0
+    end
+  end
+
+  # @return [Boolean] true if limit > 0, otherwise consider it an invalid quota
+  def valid?
+    @limit > 0
   end
 
   def to_s
@@ -129,5 +146,4 @@ class Quota
       return msg + " (#{number_to_human_size(@user_usage * BLOCK_SIZE)} are yours)"
     end
   end
-
 end

--- a/test/models/quota_test.rb
+++ b/test/models/quota_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+class QuotaTest < ActiveSupport::TestCase
+  setup do
+    @quota_defaults = {
+      type: "fileset",
+      path: "/users/efranz",
+      user: "efranz",
+      resource_type: "file",
+      user_usage: 10,
+      total_usage: 50,
+      limit: 100,
+      grace: 0, # if nil, the params will remove this
+      updated_at: Time.now
+    }
+  end
+
+  test "creating files quota instance for a fileset path" do
+    quota = Quota.new(@quota_defaults)
+
+    assert quota.valid?
+    assert_equal 10, quota.percent_user_usage
+    assert_equal 50, quota.percent_total_usage
+    assert quota.sufficient?
+    refute quota.insufficient?
+    refute quota.sufficient?(threshold: 0.09)
+    assert_equal "Using 50 files of quota 100 files (10 files are yours)", quota.to_s
+  end
+
+  test "quota invalid with limit 0" do
+    quota = Quota.new(@quota_defaults.merge(limit: 0))
+    refute quota.valid?
+
+    assert_equal 0, quota.percent_user_usage, "an invalid quota should return 0% usage"
+    assert_equal 0, quota.percent_total_usage, "an invalid quota should return 0% usage"
+
+    assert quota.sufficient?, "an invalid quota should not be flagged as insufficient"
+    refute quota.insufficient?, "an invalid quota should not be flagged as insufficient"
+
+    assert_equal "Using 50 files of quota 0 files (10 files are yours)", quota.to_s
+  end
+end


### PR DESCRIPTION
Fix edge case where quota limit is invalid, so has the value 0.
In this case we treat it like a sufficient quota so we would not warn the user.

TODO:

1. Handle other "crash" edge cases, where any of the required quota params passed to `Quota.create_both_quota_types` from the parsed file are missing. In this case we should not crash, and instead log a warning to the user. Every call to "fetch" will raise an exception.
2. Ensure that for invalid quota cases we flag this as invalid and we log a warning to the logs. 
3. Try to reproduce original problem to determine why the limit was 0 in the first place. This is something we will want to search for in the logs afterwards to see why users (such as Summer and Samuel) have the experience of having 0 set for the limit (and why this is not reproduceable for users like efranz). It might be worth setting this branch up in ondemand-dev and seeing if we can reproduce the problem there with the help of Samuel or Summer. 