### PR TITLE
Add missing motd right aligned

### DIFF
--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -13,6 +13,7 @@ class AppsController < ApplicationController
     else
       @title = nil
       @groups = OodAppGroup.groups_for(apps: nav_usr_apps)
+      @motd = MotdFile.new.formatter
       set_my_quotas
     end
   end

--- a/app/views/apps/featured.html.erb
+++ b/app/views/apps/featured.html.erb
@@ -7,11 +7,7 @@
     <br>Custom shared apps are available below.</p>
     <% end %>
     <%= render partial: "catalog_link" %>
-  </div>
-</div>
 
-<div class="row">
-  <div class="col-md-9">
     <%= render(partial: "group", collection: @groups) || "<strong>No custom shared apps available.</strong>".html_safe %>
   </div>
   <div class="col-md-3">


### PR DESCRIPTION
The MOTD is missing from the AweSim dashboard. It used to be there.

This is a screenshot of what the default would look like 

![screen 2019-01-31 at 2 24 09 pm](https://user-images.githubusercontent.com/512333/52079604-f1c94400-2563-11e9-8388-44ab5d4e1c29.png)
without

This should be in 1.5.2 and I'll use this screenshot it in the 1.5 documentation branch.