### PR TITLE
Batch connect erb fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,6 @@ tags
 !/tmp/.keep
 /public/assets
 .env.local
-/config/initializers/ood.rb
 
 # Ignore staged app
 /vendor/my_app

--- a/app/models/batch_connect/app.rb
+++ b/app/models/batch_connect/app.rb
@@ -79,15 +79,31 @@ module BatchConnect
     # Title for the batch connect app
     # @return [String] title of app
     def title
+      if Configuration.render_batch_connect_erb_for_nav?
+        title_from_erb
+      else
+        default_title
+      end
+    end
+
+    # Title to use when rendering web form
+    def title_from_erb
       form_config.fetch(:title, default_title)
     end
 
     # Default title for the batch connect app
     # @return [String] default title of app
     def default_title
-      title  = ood_app.title
-      title += ": #{sub_app.titleize}" if sub_app
-      title
+      if sub_app
+        manifest = Manifest.load(sub_app_root.join("#{sub_app}.manifest.yml").to_s)
+        if manifest.valid? && ! manifest.name.empty?
+          manifest.name
+        else
+          sub_app.titleize
+        end
+      else
+        ood_app.title
+      end
     end
 
     # Description for the batch connect app

--- a/config/configuration_singleton.rb
+++ b/config/configuration_singleton.rb
@@ -175,6 +175,10 @@ class ConfigurationSingleton
     Pathname.new(ENV['OOD_LOCALES_ROOT'] || "/etc/ood/config/locales")
   end
 
+  def render_batch_connect_erb_for_nav?
+    to_bool(ENV['OOD_RENDER_BATCH_CONNECT_ERB_FOR_NAV'])
+  end
+
   private
 
   # The environment

--- a/test/models/batch_connect/app_test.rb
+++ b/test/models/batch_connect/app_test.rb
@@ -25,15 +25,17 @@ class BatchConnect::AppTest < ActiveSupport::TestCase
     Dir.mktmpdir { |dir|
       r = PathRouter.new(dir + "/missing_app")
       assert_equal "Missing App", BatchConnect::App.new(router: r).title
-      assert_equal "Missing App: Owens Vdi", BatchConnect::App.new(router: r, sub_app: "owens-vdi").title
+      assert_equal "Owens Vdi", BatchConnect::App.new(router: r, sub_app: "owens-vdi").title
     }
   end
 
   test "form.yml.erb can use __FILE__" do
     Dir.mktmpdir { |dir|
+
       r = PathRouter.new(dir)
       r.path.join("form.yml.erb").write("---\ntitle: <%= File.expand_path(File.dirname(__FILE__)) %>")
 
+      Configuration.stubs(:render_batch_connect_erb_for_nav?).returns(true)
       app = BatchConnect::App.new(router: r)
       assert_equal dir, app.title, "When rendering form.yml.erb __FILE__ doesn't return correct value"
     }


### PR DESCRIPTION
When building navigation menu, we previously rendered the form.yml.erb
files to get the title and description.

This change prevents rendering the erb to build the navigation menu by default.

For "subapps" i.e. desktop configs, you can add a manifest per config with the same
name as the form.yml, but with .manifest.yml as the extension. Otherwise the titleized
form of the filename will be used.

For previous functionality set `OOD_RENDER_BATCH_CONNECT_ERB_FOR_NAV=1`

I copied an integration test that was already testing the interactive apps menu built because it was easy. That test can probably be simplified and setup duplication moved to a helper method - or even this set of tests moved to a separate test file - that might make things clearer.