### PR TITLE
Support fetching quota from a URL

### DIFF
--- a/app/models/quota.rb
+++ b/app/models/quota.rb
@@ -22,8 +22,8 @@ class Quota
       quotas = []
 
       # Attempt to convert path into a URI
-      uri = URI.parse(quota_path)
-      if uri.instance_of?(URI::HTTP) or uri.instance_of?(URI::HTTPS)
+      if quota_path.match(/^https?:/)
+        uri = URI.parse(quota_path)
         # If it is a URI, and it is http:// or https://
         begin
           raw = Net::HTTP.get(uri)

--- a/app/models/quota.rb
+++ b/app/models/quota.rb
@@ -27,7 +27,7 @@ class Quota
         # If it is a URI, and it is http:// or https://
         begin
           raw = Net::HTTP.get(uri)
-        rescue Exception => e
+        rescue StandardError => e
             # There are a million ways this could go wrong, assume configured correctly and is temporary issue (e.g., not a URL typo).
             Rails.logger.error("Quota URI failed to return data: #{e.message}")
             # Bail with empty results. Don't break portal because web service is down.
@@ -48,6 +48,7 @@ class Quota
         json = JSON.parse(raw)
       rescue JSON::ParserError => e
         Rails.logger.error("Quota file is not limited JSON: #{e.message}")
+	return []
       end
 
       Rails.logger.error("#{json}")

--- a/app/models/quota.rb
+++ b/app/models/quota.rb
@@ -36,7 +36,7 @@ class Quota
       else
         # If not a URL, assume it is a local file and attempt to read.
         # Assume this always works, unless configured wrong, in which case don't attempt to catch.
-        raw = quota_path.read
+        raw = Pathname.new(quota_path).read
       end
 
       # Attempt to parse raw JSON into an object

--- a/app/models/quota.rb
+++ b/app/models/quota.rb
@@ -22,7 +22,7 @@ class Quota
       quotas = []
 
       # Attempt to convert path into a URI
-      if quota_path.match(/^https?:/)
+      if quota_path.instance_of?(String) and quota_path.match(/^https?:/)
         uri = URI.parse(quota_path)
         # If it is a URI, and it is http:// or https://
         begin
@@ -35,8 +35,12 @@ class Quota
         end
       else
         # If not a URL, assume it is a local file and attempt to read.
+        # If we're fed a string, convert to Pathname. Otherwise, use as is.
+        if quota_path.instance_of?(String)
+          quota_path = Pathname.new(quota_path)
+        end
         # Assume this always works, unless configured wrong, in which case don't attempt to catch.
-        raw = Pathname.new(quota_path).read
+        raw = quota_path.read
       end
 
       # Attempt to parse raw JSON into an object

--- a/config/configuration_singleton.rb
+++ b/config/configuration_singleton.rb
@@ -80,7 +80,7 @@ class ConfigurationSingleton
   # The paths to the JSON files that store the quota information
   # @return [Array<Pathname>] quota paths
   def quota_paths
-    ENV.fetch("OOD_QUOTA_PATH", "").strip.split(":").map {|p| Pathname.new(p)}
+    ENV.fetch("OOD_QUOTA_PATH", "").strip.split(/(?<!\\):/).map {|p| p.gsub(/\\/,"")}
   end
 
   # The threshold for determining if there is sufficient quota remaining


### PR DESCRIPTION
Some additions to read quota file from a URL.

- Support escaped colon (:) delimiter in `OOD_QUOTA_PATH` env variable so we can have a URL (https://...) and not have it sliced up. I originally changed this to a comma for easy coding, but that could break other sites that already use colons.

Example:

```
OOD_QUOTA_PATH="https\\://www.rcac.purdue.edu/ws/storagedirquota/$USER"
```
Needs colon double escaped (or the "\\:" is helpfully escaped and dropped before it gets to the ruby code).

- Support having timestamp embedded with each quota data point. If not available at the data point level, it will take the global timestamp at the top of the file as it does now. Example:

```
{  
   "version":1,
   "quotas":[  
      {  
         "path":"\/scratch\/rice\/d\/ddietz",
         "user":"ddietz",
         "total_block_usage":74490668,
         "block_limit":107374182400,
         "total_file_usage":"2418",
         "file_limit":"2000000",
         "timestamp":1551277018
      },
   "timestamp":"1551278383"
}
```

On a side note, my web service call returns ALL quotas for all systems so my splash page HTML code filters the data further based on the favorite paths configured in the file explorer.

 I just realized the "over quota" warning messages might pop for other system's scratch directories, but that's probably not a bad thing. And 99% of the time a user hits the limit here, it is on their global home or global project space anyway.