### PR TITLE
[EXAMPLE] - Example of altered vnc.html

### DIFF
--- a/public/noVNC-1.0.0/app/styles/base.css
+++ b/public/noVNC-1.0.0/app/styles/base.css
@@ -900,3 +900,30 @@ select:active {
     font-size: 90px;
   }
 }
+
+/* ----------------------------------------
+ * Site Specific Customizations
+ * ----------------------------------------
+ */
+
+#safe_to_close_notification div {
+  margin: 2px;
+  padding: 5px 30px;
+  border: 1px solid rgb(83, 99, 122);
+  border-bottom-width: 1px;
+  border-bottom-width: 2px;
+  border-radius: 5px;
+  background: linear-gradient(to top, rgb(110, 132, 163), rgb(99, 119, 147));
+  vertical-align: middle;
+}
+
+#safe_to_close_notification {
+  cursor: pointer;
+  padding: 10px;
+  color: white;
+  background-color: rgb(110, 132, 163);
+  border-radius: 12px;
+  text-align: center;
+  font-size: 20px;
+  box-shadow: 6px 6px 0px rgba(0, 0, 0, 0.5);
+}

--- a/public/noVNC-1.0.0/vnc.html
+++ b/public/noVNC-1.0.0/vnc.html
@@ -54,7 +54,7 @@
     <link rel="apple-touch-icon" sizes="152x152" type="image/png" href="app/images/icons/novnc-152x152.png">
 
     <!-- Stylesheets -->
-    <link rel="stylesheet" href="app/styles/base.css" />
+    <link rel="stylesheet" href="app/styles/base.css?v=1" />
 
     <!--
     <script type='text/javascript'
@@ -268,15 +268,16 @@
     <!-- Status Dialog -->
     <div id="noVNC_status"></div>
 
-    <!-- Connect button -->
     <div class="noVNC_center">
         <div id="noVNC_connect_dlg">
             <div class="noVNC_logo" translate="no"><span>no</span>VNC</div>
-            <div id="noVNC_connect_button"><div>
-                <img src="app/images/connect.svg"> Connect
+            <div id="safe_to_close_notification" onclick="window.close();"><div>
+                Your VNC session has ended. It is safe to close this window.
             </div></div>
         </div>
     </div>
+    <!-- former Connect Button -->
+    <div id="noVNC_connect_button" style="display: none !important;"></div>
 
     <!-- Password Dialog -->
     <div class="noVNC_center noVNC_connect_layer">


### PR DESCRIPTION
The (re)connect button is mostly (entirely?) seen by users whose VNC session has ended. As such the ability to reconnect to the session is not actually offered by this control and its utility is limited. This example vnc.html and base.css remove the (re)connect button in favor of a message informing the user that their session has ended, and it is now safe to close the window.

At this time this is not intended for inclusion into OnDemand's master branch.