### PR TITLE
Namespace translations under generic or site specific and flatten hierarchies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ tags
 # Ignore data files
 /data
 config/clusters.d
+
+# SSHFS
+._*

--- a/app/controllers/batch_connect/session_contexts_controller.rb
+++ b/app/controllers/batch_connect/session_contexts_controller.rb
@@ -33,7 +33,7 @@ class BatchConnect::SessionContextsController < ApplicationController
     respond_to do |format|
       if @session.save(app: @app, context: @session_context, format: @render_format)
         cache_file.write(@session_context.to_json)  # save context to cache file
-        format.html { redirect_to batch_connect_sessions_url, notice: t('dashboard.generic_msg.batch_connect_sessions_status_blurb_create_success') }
+        format.html { redirect_to batch_connect_sessions_url, notice: t('dashboard.tr.batch_connect_sessions_status_blurb_create_success') }
         format.json { head :no_content }
       else
         format.html do

--- a/app/controllers/batch_connect/session_contexts_controller.rb
+++ b/app/controllers/batch_connect/session_contexts_controller.rb
@@ -33,7 +33,7 @@ class BatchConnect::SessionContextsController < ApplicationController
     respond_to do |format|
       if @session.save(app: @app, context: @session_context, format: @render_format)
         cache_file.write(@session_context.to_json)  # save context to cache file
-        format.html { redirect_to batch_connect_sessions_url, notice: t('dashboard.batch_connect.sessions.status_blurb.create_success') }
+        format.html { redirect_to batch_connect_sessions_url, notice: t('dashboard.generic_msg.batch_connect_sessions_status_blurb_create_success') }
         format.json { head :no_content }
       else
         format.html do

--- a/app/controllers/batch_connect/sessions_controller.rb
+++ b/app/controllers/batch_connect/sessions_controller.rb
@@ -16,12 +16,12 @@ class BatchConnect::SessionsController < ApplicationController
 
     if @session.destroy
       respond_to do |format|
-        format.html { redirect_to batch_connect_sessions_url, notice: t('dashboard.batch_connect.sessions.status_blurb.delete_success') }
+        format.html { redirect_to batch_connect_sessions_url, notice: t('dashboard.generic_msg.batch_connect_sessions_status_blurb_delete_success') }
         format.json { head :no_content }
       end
     else
       respond_to do |format|
-        format.html { redirect_to batch_connect_sessions_url, alert: t('dashboard.batch_connect.sessions.status_blurb.delete_failure') }
+        format.html { redirect_to batch_connect_sessions_url, alert: t('dashboard.generic_msg.batch_connect_sessions_status_blurb_delete_failure') }
         format.json { render json: @session.errors, status: :unprocessable_entity }
       end
     end

--- a/app/controllers/batch_connect/sessions_controller.rb
+++ b/app/controllers/batch_connect/sessions_controller.rb
@@ -16,12 +16,12 @@ class BatchConnect::SessionsController < ApplicationController
 
     if @session.destroy
       respond_to do |format|
-        format.html { redirect_to batch_connect_sessions_url, notice: t('dashboard.generic_msg.batch_connect_sessions_status_blurb_delete_success') }
+        format.html { redirect_to batch_connect_sessions_url, notice: t('dashboard.tr.batch_connect_sessions_status_blurb_delete_success') }
         format.json { head :no_content }
       end
     else
       respond_to do |format|
-        format.html { redirect_to batch_connect_sessions_url, alert: t('dashboard.generic_msg.batch_connect_sessions_status_blurb_delete_failure') }
+        format.html { redirect_to batch_connect_sessions_url, alert: t('dashboard.tr.batch_connect_sessions_status_blurb_delete_failure') }
         format.json { render json: @session.errors, status: :unprocessable_entity }
       end
     end

--- a/app/controllers/concerns/batch_connect_concern.rb
+++ b/app/controllers/concerns/batch_connect_concern.rb
@@ -12,7 +12,7 @@ module BatchConnectConcern
     if apps.empty?
       []
     else
-      [ OodAppGroup.new(title: t('dashboard.generic_msg.shared_apps_title'), apps: apps) ]
+      [ OodAppGroup.new(title: t('dashboard.tr.shared_apps_title'), apps: apps) ]
     end
   end
 

--- a/app/controllers/concerns/batch_connect_concern.rb
+++ b/app/controllers/concerns/batch_connect_concern.rb
@@ -12,7 +12,7 @@ module BatchConnectConcern
     if apps.empty?
       []
     else
-      [ OodAppGroup.new(title: t('dashboard.apps.shared_apps_title'), apps: apps) ]
+      [ OodAppGroup.new(title: t('dashboard.generic_msg.shared_apps_title'), apps: apps) ]
     end
   end
 

--- a/app/helpers/batch_connect/session_contexts_helper.rb
+++ b/app/helpers/batch_connect/session_contexts_helper.rb
@@ -51,7 +51,7 @@ module BatchConnect::SessionContextsHelper
         end
       )
       concat content_tag(:span, opts[:help], class: "help-block") if opts[:help]
-      concat button_tag(t('dashboard.batch_connect.form.reset_resolution'), id: "#{id}_reset", type: "button", class: "btn btn-default")
+      concat button_tag(t('dashboard.generic_msg.batch_connect_form_reset_resolution'), id: "#{id}_reset", type: "button", class: "btn btn-default")
       concat(
         content_tag(:script) do
           <<-EOT.html_safe

--- a/app/helpers/batch_connect/session_contexts_helper.rb
+++ b/app/helpers/batch_connect/session_contexts_helper.rb
@@ -51,7 +51,7 @@ module BatchConnect::SessionContextsHelper
         end
       )
       concat content_tag(:span, opts[:help], class: "help-block") if opts[:help]
-      concat button_tag(t('dashboard.generic_msg.batch_connect_form_reset_resolution'), id: "#{id}_reset", type: "button", class: "btn btn-default")
+      concat button_tag(t('dashboard.tr.batch_connect_form_reset_resolution'), id: "#{id}_reset", type: "button", class: "btn btn-default")
       concat(
         content_tag(:script) do
           <<-EOT.html_safe

--- a/app/helpers/batch_connect/sessions_helper.rb
+++ b/app/helpers/batch_connect/sessions_helper.rb
@@ -50,7 +50,7 @@ module BatchConnect::SessionsHelper
 
   def created(session)
     content_tag(:p) do
-      concat content_tag(:strong, t('dashboard.batch_connect.sessions.stats.created_at'))
+      concat content_tag(:strong, t('dashboard.generic_msg.batch_connect_sessions_stats_created_at'))
       concat " "
       concat Time.at(session.created_at).localtime.strftime("%Y-%m-%d %H:%M:%S %Z")
     end
@@ -63,17 +63,17 @@ module BatchConnect::SessionsHelper
     content_tag(:p) do
       if session.starting? || session.running?
         if time_limit && time_used
-          concat content_tag(:strong, t('dashboard.batch_connect.sessions.stats.time_remaining'))
+          concat content_tag(:strong, t('dashboard.generic_msg.batch_connect_sessions_stats_time_remaining'))
           concat " "
           concat distance_of_time_in_words(time_limit - time_used, 0, false, :only => [:minutes, :hours], :accumulate_on => :hours)
         elsif time_used
-          concat content_tag(:strong, t('dashboard.batch_connect.sessions.stats.time_used'))
+          concat content_tag(:strong, t('dashboard.generic_msg.batch_connect_sessions_stats_time_used'))
           concat " "
           concat distance_of_time_in_words(time_used, 0, false, :only => [:minutes, :hours], :accumulate_on => :hours)
         end
       else  # not starting or running
         if time_limit
-          concat content_tag(:strong, t('dashboard.batch_connect.sessions.stats.time_requested'))
+          concat content_tag(:strong, t('dashboard.generic_msg.batch_connect_sessions_stats_time_requested'))
           concat " "
           concat distance_of_time_in_words(time_limit, 0, false, :only => [:minutes, :hours], :accumulate_on => :hours)
         end
@@ -83,15 +83,15 @@ module BatchConnect::SessionsHelper
 
   def host(session)
     content_tag(:p) do
-      concat content_tag(:strong, t('dashboard.batch_connect.sessions.stats.host'))
+      concat content_tag(:strong, t('dashboard.batch_connect_sessions_stats_host'))
       concat " "
-      concat session.connect.host || t('dashboard.batch_connect.sessions.stats.undetermined_host')
+      concat session.connect.host || t('dashboard.generic_msg.batch_connect_sessions_stats_undetermined_host')
     end if session.running?
   end
 
   def id(session)
     content_tag(:p) do
-      concat content_tag(:strong, t('dashboard.batch_connect.sessions.stats.session_id'))
+      concat content_tag(:strong, t('dashboard.generic_msg.batch_connect_sessions_stats_session_id'))
       concat " "
       concat(
         link_to(
@@ -135,12 +135,12 @@ module BatchConnect::SessionsHelper
 
   def delete(session)
     link_to(
-      icon("fas", "trash-alt", t('dashboard.batch_connect.sessions.delete.title'), class: "fa-fw"),
+      icon("fas", "trash-alt", t('dashboard.generic_msg.batch_connect_sessions_delete_title'), class: "fa-fw"),
       session,
       method: :delete,
       class: "btn btn-danger pull-right btn-delete",
-      title: t('dashboard.batch_connect.sessions.delete.hover'),
-      data: { confirm: t('dashboard.batch_connect.sessions.delete.confirm'), toggle: "tooltip", placement: "bottom"}
+      title: t('dashboard.generic_msg.batch_connect_sessions_delete_hover'),
+      data: { confirm: t('dashboard.generic_msg.batch_connect_sessions_delete_confirm'), toggle: "tooltip", placement: "bottom"}
     )
   end
 
@@ -156,10 +156,10 @@ module BatchConnect::SessionsHelper
       errors.keys.each do |key|
         case key
         when :submit
-          concat content_tag(:h4, t('dashboard.batch_connect.sessions.errors.submission'))
+          concat content_tag(:h4, t('dashboard.generic_msg.batch_connect_sessions_errors_submission'))
           concat content_tag(:pre, errors[key].first)
         when :stage
-          concat content_tag(:h4, t('dashboard.batch_connect.sessions.errors.staging'))
+          concat content_tag(:h4, t('dashboard.generic_msg.batch_connect_sessions_errors_staging'))
           concat content_tag(:pre, errors[key].first)
         else
           errors[key].each { |m| concat content_tag(:h4, m) }

--- a/app/helpers/batch_connect/sessions_helper.rb
+++ b/app/helpers/batch_connect/sessions_helper.rb
@@ -50,7 +50,7 @@ module BatchConnect::SessionsHelper
 
   def created(session)
     content_tag(:p) do
-      concat content_tag(:strong, t('dashboard.generic_msg.batch_connect_sessions_stats_created_at'))
+      concat content_tag(:strong, t('dashboard.tr.batch_connect_sessions_stats_created_at'))
       concat " "
       concat Time.at(session.created_at).localtime.strftime("%Y-%m-%d %H:%M:%S %Z")
     end
@@ -63,17 +63,17 @@ module BatchConnect::SessionsHelper
     content_tag(:p) do
       if session.starting? || session.running?
         if time_limit && time_used
-          concat content_tag(:strong, t('dashboard.generic_msg.batch_connect_sessions_stats_time_remaining'))
+          concat content_tag(:strong, t('dashboard.tr.batch_connect_sessions_stats_time_remaining'))
           concat " "
           concat distance_of_time_in_words(time_limit - time_used, 0, false, :only => [:minutes, :hours], :accumulate_on => :hours)
         elsif time_used
-          concat content_tag(:strong, t('dashboard.generic_msg.batch_connect_sessions_stats_time_used'))
+          concat content_tag(:strong, t('dashboard.tr.batch_connect_sessions_stats_time_used'))
           concat " "
           concat distance_of_time_in_words(time_used, 0, false, :only => [:minutes, :hours], :accumulate_on => :hours)
         end
       else  # not starting or running
         if time_limit
-          concat content_tag(:strong, t('dashboard.generic_msg.batch_connect_sessions_stats_time_requested'))
+          concat content_tag(:strong, t('dashboard.tr.batch_connect_sessions_stats_time_requested'))
           concat " "
           concat distance_of_time_in_words(time_limit, 0, false, :only => [:minutes, :hours], :accumulate_on => :hours)
         end
@@ -85,13 +85,13 @@ module BatchConnect::SessionsHelper
     content_tag(:p) do
       concat content_tag(:strong, t('dashboard.batch_connect_sessions_stats_host'))
       concat " "
-      concat session.connect.host || t('dashboard.generic_msg.batch_connect_sessions_stats_undetermined_host')
+      concat session.connect.host || t('dashboard.tr.batch_connect_sessions_stats_undetermined_host')
     end if session.running?
   end
 
   def id(session)
     content_tag(:p) do
-      concat content_tag(:strong, t('dashboard.generic_msg.batch_connect_sessions_stats_session_id'))
+      concat content_tag(:strong, t('dashboard.tr.batch_connect_sessions_stats_session_id'))
       concat " "
       concat(
         link_to(
@@ -135,12 +135,12 @@ module BatchConnect::SessionsHelper
 
   def delete(session)
     link_to(
-      icon("fas", "trash-alt", t('dashboard.generic_msg.batch_connect_sessions_delete_title'), class: "fa-fw"),
+      icon("fas", "trash-alt", t('dashboard.tr.batch_connect_sessions_delete_title'), class: "fa-fw"),
       session,
       method: :delete,
       class: "btn btn-danger pull-right btn-delete",
-      title: t('dashboard.generic_msg.batch_connect_sessions_delete_hover'),
-      data: { confirm: t('dashboard.generic_msg.batch_connect_sessions_delete_confirm'), toggle: "tooltip", placement: "bottom"}
+      title: t('dashboard.tr.batch_connect_sessions_delete_hover'),
+      data: { confirm: t('dashboard.tr.batch_connect_sessions_delete_confirm'), toggle: "tooltip", placement: "bottom"}
     )
   end
 
@@ -156,10 +156,10 @@ module BatchConnect::SessionsHelper
       errors.keys.each do |key|
         case key
         when :submit
-          concat content_tag(:h4, t('dashboard.generic_msg.batch_connect_sessions_errors_submission'))
+          concat content_tag(:h4, t('dashboard.tr.batch_connect_sessions_errors_submission'))
           concat content_tag(:pre, errors[key].first)
         when :stage
-          concat content_tag(:h4, t('dashboard.generic_msg.batch_connect_sessions_errors_staging'))
+          concat content_tag(:h4, t('dashboard.tr.batch_connect_sessions_errors_staging'))
           concat content_tag(:pre, errors[key].first)
         else
           errors[key].each { |m| concat content_tag(:h4, m) }

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -2,9 +2,9 @@ module ProductsHelper
 
   def products_title(type)
     if type == :dev
-      t('dashboard.generic_msg.nav_develop_my_sandbox_apps_dev')
+      t('dashboard.tr.nav_develop_my_sandbox_apps_dev')
     elsif type == :usr
-      t('dashboard.generic_msg.nav_develop_my_sandbox_apps_prod')
+      t('dashboard.tr.nav_develop_my_sandbox_apps_prod')
     else
       "Undefined Title"
     end

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -2,9 +2,9 @@ module ProductsHelper
 
   def products_title(type)
     if type == :dev
-      "My Sandbox Apps (Development)"
+      t('dashboard.generic_msg.nav_develop_my_sandbox_apps_dev')
     elsif type == :usr
-      "My Shared Apps (Production)"
+      t('dashboard.generic_msg.nav_develop_my_sandbox_apps_prod')
     else
       "Undefined Title"
     end

--- a/app/models/quota.rb
+++ b/app/models/quota.rb
@@ -165,13 +165,13 @@ class Quota
 
   def to_s
     if @resource_type == "file"
-      msg = I18n.translate('dashboard.generic_msg.quota_file', used: number_to_human(@total_usage).downcase, available: number_to_human(@limit).downcase)
+      msg = I18n.translate('dashboard.tr.quota_file', used: number_to_human(@total_usage).downcase, available: number_to_human(@limit).downcase)
       return msg unless self.shared?
-      return msg + " #{I18n.translate('dashboard.generic_msg.quota_file_shared', used_exclusive: number_to_human(@user_usage).downcase)}"
+      return msg + " #{I18n.translate('dashboard.tr.quota_file_shared', used_exclusive: number_to_human(@user_usage).downcase)}"
     elsif @resource_type == "block"
-      msg = I18n.translate('dashboard.generic_msg.quota_block', used: number_to_human_size(@total_usage * BLOCK_SIZE), available: number_to_human_size(@limit * BLOCK_SIZE))
+      msg = I18n.translate('dashboard.tr.quota_block', used: number_to_human_size(@total_usage * BLOCK_SIZE), available: number_to_human_size(@limit * BLOCK_SIZE))
       return msg unless self.shared?
-      return msg + " #{I18n.translate('dashboard.generic_msg.quota_block_shared', used_exclusive: number_to_human_size(@user_usage * BLOCK_SIZE))}"
+      return msg + " #{I18n.translate('dashboard.tr.quota_block_shared', used_exclusive: number_to_human_size(@user_usage * BLOCK_SIZE))}"
     end
   end
 end

--- a/app/models/quota.rb
+++ b/app/models/quota.rb
@@ -165,13 +165,13 @@ class Quota
 
   def to_s
     if @resource_type == "file"
-      msg = I18n.translate('dashboard.quota.file', used: number_to_human(@total_usage).downcase, available: number_to_human(@limit).downcase)
+      msg = I18n.translate('dashboard.generic_msg.quota_file', used: number_to_human(@total_usage).downcase, available: number_to_human(@limit).downcase)
       return msg unless self.shared?
-      return msg + " #{I18n.translate('dashboard.quota.file_shared', used_exclusive: number_to_human(@user_usage).downcase)}"
+      return msg + " #{I18n.translate('dashboard.generic_msg.quota_file_shared', used_exclusive: number_to_human(@user_usage).downcase)}"
     elsif @resource_type == "block"
-      msg = I18n.translate('dashboard.quota.block', used: number_to_human_size(@total_usage * BLOCK_SIZE), available: number_to_human_size(@limit * BLOCK_SIZE))
+      msg = I18n.translate('dashboard.generic_msg.quota_block', used: number_to_human_size(@total_usage * BLOCK_SIZE), available: number_to_human_size(@limit * BLOCK_SIZE))
       return msg unless self.shared?
-      return msg + " #{I18n.translate('dashboard.quota.block_shared', used_exclusive: number_to_human_size(@user_usage * BLOCK_SIZE))}"
+      return msg + " #{I18n.translate('dashboard.generic_msg.quota_block_shared', used_exclusive: number_to_human_size(@user_usage * BLOCK_SIZE))}"
     end
   end
 end

--- a/app/views/apps/_catalog_link.html.erb
+++ b/app/views/apps/_catalog_link.html.erb
@@ -1,11 +1,11 @@
 <p>
   <% if ENV['OOD_DASHBOARD_SUPPORT_URL'].present? %>
-  <%= t('dashboard.sharing.support_msg_html', support_url: ENV['OOD_DASHBOARD_SUPPORT_URL']) %>
+  <%= t('dashboard.generic_msg.sharing_support_msg_html', support_url: ENV['OOD_DASHBOARD_SUPPORT_URL']) %>
   <% end %>
 
   <% if ENV['OOD_APP_CATALOG_URL'].present? %>
   <%= t(  'dashboard.sharing.catalog_msg_html',
-          catalog_link_tag: link_to(  t('dashboard.sharing.catalog_title'),
+          catalog_link_tag: link_to(  t('dashboard.generic_msg.sharing_catalog_title'),
                                       ENV['OOD_APP_CATALOG_URL']
                                     )
         )

--- a/app/views/apps/_catalog_link.html.erb
+++ b/app/views/apps/_catalog_link.html.erb
@@ -1,11 +1,11 @@
 <p>
   <% if ENV['OOD_DASHBOARD_SUPPORT_URL'].present? %>
-  <%= t('dashboard.generic_msg.sharing_support_msg_html', support_url: ENV['OOD_DASHBOARD_SUPPORT_URL']) %>
+  <%= t('dashboard.tr.sharing_support_msg_html', support_url: ENV['OOD_DASHBOARD_SUPPORT_URL']) %>
   <% end %>
 
   <% if ENV['OOD_APP_CATALOG_URL'].present? %>
   <%= t(  'dashboard.sharing.catalog_msg_html',
-          catalog_link_tag: link_to(  t('dashboard.generic_msg.sharing_catalog_title'),
+          catalog_link_tag: link_to(  t('dashboard.tr.sharing_catalog_title'),
                                       ENV['OOD_APP_CATALOG_URL']
                                     )
         )

--- a/app/views/apps/featured.html.erb
+++ b/app/views/apps/featured.html.erb
@@ -3,11 +3,11 @@
     <%= render partial: 'shared/welcome' %>
 
     <% if @nav_groups.any? %>
-    <p class="lead"><%= t('dashboard.sharing.welcome_msg_html') %></p>
+    <p class="lead"><%= t('dashboard.generic_msg.sharing_welcome_msg_html') %></p>
     <% end %>
     <%= render partial: "catalog_link" %>
 
-    <%= render(partial: "group", collection: @groups) || t('dashboard.sharing.no_shared_apps_html') %>
+    <%= render(partial: "group", collection: @groups) || t('dashboard.generic_msg.sharing_no_shared_apps_html') %>
   </div>
   <div class="col-md-3">
     <%# This assumes @motd_file responds to `to_partial_path` %>

--- a/app/views/apps/featured.html.erb
+++ b/app/views/apps/featured.html.erb
@@ -3,11 +3,11 @@
     <%= render partial: 'shared/welcome' %>
 
     <% if @nav_groups.any? %>
-    <p class="lead"><%= t('dashboard.generic_msg.sharing_welcome_msg_html') %></p>
+    <p class="lead"><%= t('dashboard.tr.sharing_welcome_msg_html') %></p>
     <% end %>
     <%= render partial: "catalog_link" %>
 
-    <%= render(partial: "group", collection: @groups) || t('dashboard.generic_msg.sharing_no_shared_apps_html') %>
+    <%= render(partial: "group", collection: @groups) || t('dashboard.tr.sharing_no_shared_apps_html') %>
   </div>
   <div class="col-md-3">
     <%# This assumes @motd_file responds to `to_partial_path` %>

--- a/app/views/apps/index.html.erb
+++ b/app/views/apps/index.html.erb
@@ -1,16 +1,16 @@
 <ol class="breadcrumb">
   <li>
-    <%= link_to t('dashboard.breadcrumbs.home'), root_path %>
+    <%= link_to t('dashboard.generic_msg.breadcrumbs_home'), root_path %>
   </li>
   <li class="active">
-    <%= t('dashboard.breadcrumbs.all_apps') %>
+    <%= t('dashboard.generic_msg.breadcrumbs_all_apps') %>
   </li>
 </ol>
 
 <div class="row">
   <div class="col-md-3">
     <div class="panel panel-default">
-      <div class="panel-heading"><%= t('dashboard.apps.system_apps_title') %></div>
+      <div class="panel-heading"><%= t('dashboard.generic_msg.apps_system_apps_title') %></div>
       <div class="panel-body">
         <%= render partial: "app_list", collection: @core_app_groups %>
       </div>

--- a/app/views/apps/index.html.erb
+++ b/app/views/apps/index.html.erb
@@ -1,16 +1,16 @@
 <ol class="breadcrumb">
   <li>
-    <%= link_to t('dashboard.generic_msg.breadcrumbs_home'), root_path %>
+    <%= link_to t('dashboard.tr.breadcrumbs_home'), root_path %>
   </li>
   <li class="active">
-    <%= t('dashboard.generic_msg.breadcrumbs_all_apps') %>
+    <%= t('dashboard.tr.breadcrumbs_all_apps') %>
   </li>
 </ol>
 
 <div class="row">
   <div class="col-md-3">
     <div class="panel panel-default">
-      <div class="panel-heading"><%= t('dashboard.generic_msg.apps_system_apps_title') %></div>
+      <div class="panel-heading"><%= t('dashboard.tr.apps_system_apps_title') %></div>
       <div class="panel-body">
         <%= render partial: "app_list", collection: @core_app_groups %>
       </div>

--- a/app/views/apps/restart.html.erb
+++ b/app/views/apps/restart.html.erb
@@ -2,10 +2,10 @@
   <meta http-equiv="refresh" content="5;url=<%= restart_url %>">
 <% end %>
 
-<h2><%= t('dashboard.nav.restart_server') %></h2>
+<h2><%= t('dashboard.generic_msg.nav_restart_server') %></h2>
 
 <p class="lead">
-  <%= t(  'dashboard.restart_msg_html',
+  <%= t(  'dashboard.generic_msg.restart_msg_html',
           restart_url: restart_url
         )
   %>

--- a/app/views/apps/restart.html.erb
+++ b/app/views/apps/restart.html.erb
@@ -2,10 +2,10 @@
   <meta http-equiv="refresh" content="5;url=<%= restart_url %>">
 <% end %>
 
-<h2><%= t('dashboard.generic_msg.nav_restart_server') %></h2>
+<h2><%= t('dashboard.tr.nav_restart_server') %></h2>
 
 <p class="lead">
-  <%= t(  'dashboard.generic_msg.restart_msg_html',
+  <%= t(  'dashboard.tr.restart_msg_html',
           restart_url: restart_url
         )
   %>

--- a/app/views/apps/setup_failed.html.erb
+++ b/app/views/apps/setup_failed.html.erb
@@ -1,4 +1,4 @@
-<%= t(  'dashboard.generic_msg.apps_setup_failure_html',
+<%= t(  'dashboard.tr.apps_setup_failure_html',
         app_url: @app_url,
         home_url: root_path,
         exception_class: @exception.class,

--- a/app/views/apps/setup_failed.html.erb
+++ b/app/views/apps/setup_failed.html.erb
@@ -1,4 +1,4 @@
-<%= t(  'dashboard.apps.setup_failure_html',
+<%= t(  'dashboard.generic_msg.apps_setup_failure_html',
         app_url: @app_url,
         home_url: root_path,
         exception_class: @exception.class,

--- a/app/views/batch_connect/session_contexts/_form.html.erb
+++ b/app/views/batch_connect/session_contexts/_form.html.erb
@@ -3,7 +3,7 @@
     <%= create_widget(f, attrib, format: @render_format) %>
   <% end %>
 
-  <%= f.submit t('dashboard.batch_connect.form.launch'), class: "btn btn-primary btn-block" %>
+  <%= f.submit t('dashboard.generic_msg.batch_connect_form_launch'), class: "btn btn-primary btn-block" %>
 <% end %>
 
 <% @app.custom_javascript_files.each do |jsfile| %>

--- a/app/views/batch_connect/session_contexts/_form.html.erb
+++ b/app/views/batch_connect/session_contexts/_form.html.erb
@@ -3,7 +3,7 @@
     <%= create_widget(f, attrib, format: @render_format) %>
   <% end %>
 
-  <%= f.submit t('dashboard.generic_msg.batch_connect_form_launch'), class: "btn btn-primary btn-block" %>
+  <%= f.submit t('dashboard.tr.batch_connect_form_launch'), class: "btn btn-primary btn-block" %>
 <% end %>
 
 <% @app.custom_javascript_files.each do |jsfile| %>

--- a/app/views/batch_connect/session_contexts/new.html.erb
+++ b/app/views/batch_connect/session_contexts/new.html.erb
@@ -2,10 +2,10 @@
 
 <ol class="breadcrumb">
   <li>
-    <%= link_to t('dashboard.generic_msg.breadcrumbs_home'), root_path %>
+    <%= link_to t('dashboard.tr.breadcrumbs_home'), root_path %>
   </li>
   <li>
-    <%= link_to t('dashboard.generic_msg.breadcrumbs_my_sessions'), batch_connect_sessions_path %>
+    <%= link_to t('dashboard.tr.breadcrumbs_my_sessions'), batch_connect_sessions_path %>
   </li>
   <li class="active">
     <%= @app.title %>
@@ -20,10 +20,10 @@
     <%= session_save_errors @session.errors %>
 
     <p class="small">
-      <%= t('dashboard.generic_msg.batch_connect_sessions_data_html',
+      <%= t('dashboard.tr.batch_connect_sessions_data_html',
             title: @app.title,
             data_link_tag: link_to(
-              t('dashboard.generic_msg.batch_connect_sessions_staged_root'),
+              t('dashboard.tr.batch_connect_sessions_staged_root'),
               OodAppkit.files.url(path: @session.staged_root).to_s,
               target: "_blank")
             )
@@ -56,10 +56,10 @@
         <%= render "form" %>
 
         <p class="small">
-          <%= t('dashboard.generic_msg.batch_connect_form_session_data_html',
+          <%= t('dashboard.tr.batch_connect_form_session_data_html',
                 title: @app.title,
                 data_link_tag: link_to(
-                  t('dashboard.generic_msg.batch_connect_form_data_root'),
+                  t('dashboard.tr.batch_connect_form_data_root'),
                   OodAppkit.files.url(
                     path: BatchConnect::Session.dataroot(@app.token)
                   ).to_s,

--- a/app/views/batch_connect/session_contexts/new.html.erb
+++ b/app/views/batch_connect/session_contexts/new.html.erb
@@ -2,10 +2,10 @@
 
 <ol class="breadcrumb">
   <li>
-    <%= link_to t('dashboard.breadcrumbs.home'), root_path %>
+    <%= link_to t('dashboard.generic_msg.breadcrumbs_home'), root_path %>
   </li>
   <li>
-    <%= link_to t('dashboard.breadcrumbs.my_sessions'), batch_connect_sessions_path %>
+    <%= link_to t('dashboard.generic_msg.breadcrumbs_my_sessions'), batch_connect_sessions_path %>
   </li>
   <li class="active">
     <%= @app.title %>
@@ -20,10 +20,10 @@
     <%= session_save_errors @session.errors %>
 
     <p class="small">
-      <%= t('dashboard.batch_connect.sessions.data_html',
+      <%= t('dashboard.generic_msg.batch_connect_sessions_data_html',
             title: @app.title,
             data_link_tag: link_to(
-              t('dashboard.batch_connect.sessions.staged_root'),
+              t('dashboard.generic_msg.batch_connect_sessions_staged_root'),
               OodAppkit.files.url(path: @session.staged_root).to_s,
               target: "_blank")
             )
@@ -56,10 +56,10 @@
         <%= render "form" %>
 
         <p class="small">
-          <%= t('dashboard.batch_connect.form.session_data_html',
+          <%= t('dashboard.generic_msg.batch_connect_form_session_data_html',
                 title: @app.title,
                 data_link_tag: link_to(
-                  t('dashboard.batch_connect.form.data_root'),
+                  t('dashboard.generic_msg.batch_connect_form_data_root'),
                   OodAppkit.files.url(
                     path: BatchConnect::Session.dataroot(@app.token)
                   ).to_s,

--- a/app/views/batch_connect/sessions/connections/_bad.html.erb
+++ b/app/views/batch_connect/sessions/connections/_bad.html.erb
@@ -1,3 +1,3 @@
 <p>
-  <%= t('dashboard.site.batch_connect_sessions_status_bad') %>
+  <%= t('dashboard.batch_connect_sessions_status_bad') %>
 </p>

--- a/app/views/batch_connect/sessions/connections/_bad.html.erb
+++ b/app/views/batch_connect/sessions/connections/_bad.html.erb
@@ -1,3 +1,3 @@
 <p>
-  <%= t('dashboard.site_specific.batch_connect_sessions_status_bad') %>
+  <%= t('dashboard.site.batch_connect_sessions_status_bad') %>
 </p>

--- a/app/views/batch_connect/sessions/connections/_bad.html.erb
+++ b/app/views/batch_connect/sessions/connections/_bad.html.erb
@@ -1,3 +1,3 @@
 <p>
-  <%= t('dashboard.batch_connect.sessions.status.bad') %>
+  <%= t('dashboard.site_specific.batch_connect_sessions_status_bad') %>
 </p>

--- a/app/views/batch_connect/sessions/connections/_missing_connection.html.erb
+++ b/app/views/batch_connect/sessions/connections/_missing_connection.html.erb
@@ -1,3 +1,3 @@
 <p>
-  <%= t('dashboard.batch_connect.sessions.status.missing_connection') %>
+  <%= t('dashboard.site_specific.batch_connect_sessions_status_missing_connection') %>
 </p>

--- a/app/views/batch_connect/sessions/connections/_missing_connection.html.erb
+++ b/app/views/batch_connect/sessions/connections/_missing_connection.html.erb
@@ -1,3 +1,3 @@
 <p>
-  <%= t('dashboard.site_specific.batch_connect_sessions_status_missing_connection') %>
+  <%= t('dashboard.site.batch_connect_sessions_status_missing_connection') %>
 </p>

--- a/app/views/batch_connect/sessions/connections/_missing_connection.html.erb
+++ b/app/views/batch_connect/sessions/connections/_missing_connection.html.erb
@@ -1,3 +1,3 @@
 <p>
-  <%= t('dashboard.site.batch_connect_sessions_status_missing_connection') %>
+  <%= t('dashboard.batch_connect_sessions_status_missing_connection') %>
 </p>

--- a/app/views/batch_connect/sessions/connections/_novnc.html.erb
+++ b/app/views/batch_connect/sessions/connections/_novnc.html.erb
@@ -1,2 +1,2 @@
-<%= link_to icon('fas', 'eye', t('dashboard.generic_msg.batch_connect_sessions_novnc_launch')), novnc_link(connect), class: 'btn btn-primary', target: '_blank' %>
-<%= link_to t('dashboard.generic_msg.batch_connect_sessions_novnc_view_only'), novnc_link(connect, view_only: true), class: 'btn btn-default pull-right', target: '_blank' %>
+<%= link_to icon('fas', 'eye', t('dashboard.tr.batch_connect_sessions_novnc_launch')), novnc_link(connect), class: 'btn btn-primary', target: '_blank' %>
+<%= link_to t('dashboard.tr.batch_connect_sessions_novnc_view_only'), novnc_link(connect, view_only: true), class: 'btn btn-default pull-right', target: '_blank' %>

--- a/app/views/batch_connect/sessions/connections/_novnc.html.erb
+++ b/app/views/batch_connect/sessions/connections/_novnc.html.erb
@@ -1,2 +1,2 @@
-<%= link_to icon('fas', 'eye', t('dashboard.batch_connect.sessions.novnc.launch')), novnc_link(connect), class: 'btn btn-primary', target: '_blank' %>
-<%= link_to t('dashboard.batch_connect.sessions.novnc.view_only'), novnc_link(connect, view_only: true), class: 'btn btn-default pull-right', target: '_blank' %>
+<%= link_to icon('fas', 'eye', t('dashboard.generic_msg.batch_connect_sessions_novnc_launch')), novnc_link(connect), class: 'btn btn-primary', target: '_blank' %>
+<%= link_to t('dashboard.generic_msg.batch_connect_sessions_novnc_view_only'), novnc_link(connect, view_only: true), class: 'btn btn-default pull-right', target: '_blank' %>

--- a/app/views/batch_connect/sessions/connections/_queued.html.erb
+++ b/app/views/batch_connect/sessions/connections/_queued.html.erb
@@ -1,3 +1,3 @@
 <p>
-  <%= t('dashboard.batch_connect.sessions.status.queued') %>
+  <%= t('dashboard.site_specific.batch_connect_sessions_status_queued') %>
 </p>

--- a/app/views/batch_connect/sessions/connections/_queued.html.erb
+++ b/app/views/batch_connect/sessions/connections/_queued.html.erb
@@ -1,3 +1,3 @@
 <p>
-  <%= t('dashboard.site.batch_connect_sessions_status_queued') %>
+  <%= t('dashboard.batch_connect_sessions_status_queued') %>
 </p>

--- a/app/views/batch_connect/sessions/connections/_queued.html.erb
+++ b/app/views/batch_connect/sessions/connections/_queued.html.erb
@@ -1,3 +1,3 @@
 <p>
-  <%= t('dashboard.site_specific.batch_connect_sessions_status_queued') %>
+  <%= t('dashboard.site.batch_connect_sessions_status_queued') %>
 </p>

--- a/app/views/batch_connect/sessions/connections/_starting.html.erb
+++ b/app/views/batch_connect/sessions/connections/_starting.html.erb
@@ -1,3 +1,3 @@
 <p>
-  <%= t('dashboard.generic_msg.batch_connect_sessions_status_starting') %>
+  <%= t('dashboard.tr.batch_connect_sessions_status_starting') %>
 </p>

--- a/app/views/batch_connect/sessions/connections/_starting.html.erb
+++ b/app/views/batch_connect/sessions/connections/_starting.html.erb
@@ -1,3 +1,3 @@
 <p>
-  <%= t('dashboard.batch_connect.sessions.status.starting') %>
+  <%= t('dashboard.generic_msg.batch_connect_sessions_status_starting') %>
 </p>

--- a/app/views/batch_connect/sessions/index.html.erb
+++ b/app/views/batch_connect/sessions/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('dashboard.breadcrumbs.my_sessions') %>
+<% content_for :title, t('dashboard.generic_msg.breadcrumbs_my_sessions') %>
 
 <%-
   any_apps = (@sys_app_groups + @usr_app_groups + @dev_app_groups).any?
@@ -6,10 +6,10 @@
 
 <ol class="breadcrumb">
   <li>
-    <%= link_to t('dashboard.breadcrumbs.home'), root_path %>
+    <%= link_to t('dashboard.generic_msg.breadcrumbs_home'), root_path %>
   </li>
   <li class="active">
-    <%= t('dashboard.breadcrumbs.my_sessions') %>
+    <%= t('dashboard.generic_msg.breadcrumbs_my_sessions') %>
   </li>
 </ol>
 
@@ -31,7 +31,7 @@
       <div class="batch-connect sessions" data-toggle="poll" data-url="<%= batch_connect_sessions_path(format: :js) %>" data-delay="<%= ENV["POLL_DELAY"] || 10000 %>">
         <% if @sessions.empty? %>
           <div class="ood-appkit markdown">
-            <p><%= t('dashboard.batch_connect.no_sessions') %></p>
+            <p><%= t('dashboard.generic_msg.batch_connect_no_sessions') %></p>
           </div>
         <% else %>
           <%= render partial: "panel", collection: @sessions, as: :session %>
@@ -41,7 +41,7 @@
   <%- else -%>
     <div class="col-md-12">
       <div class="ood-appkit markdown">
-        <p><%= t('dashboard.batch_connect.no_apps') %></p>
+        <p><%= t('dashboard.generic_msg.batch_connect_no_apps') %></p>
       </div>
     </div>
   <%- end -%>

--- a/app/views/batch_connect/sessions/index.html.erb
+++ b/app/views/batch_connect/sessions/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('dashboard.generic_msg.breadcrumbs_my_sessions') %>
+<% content_for :title, t('dashboard.tr.breadcrumbs_my_sessions') %>
 
 <%-
   any_apps = (@sys_app_groups + @usr_app_groups + @dev_app_groups).any?
@@ -6,10 +6,10 @@
 
 <ol class="breadcrumb">
   <li>
-    <%= link_to t('dashboard.generic_msg.breadcrumbs_home'), root_path %>
+    <%= link_to t('dashboard.tr.breadcrumbs_home'), root_path %>
   </li>
   <li class="active">
-    <%= t('dashboard.generic_msg.breadcrumbs_my_sessions') %>
+    <%= t('dashboard.tr.breadcrumbs_my_sessions') %>
   </li>
 </ol>
 
@@ -31,7 +31,7 @@
       <div class="batch-connect sessions" data-toggle="poll" data-url="<%= batch_connect_sessions_path(format: :js) %>" data-delay="<%= ENV["POLL_DELAY"] || 10000 %>">
         <% if @sessions.empty? %>
           <div class="ood-appkit markdown">
-            <p><%= t('dashboard.generic_msg.batch_connect_no_sessions') %></p>
+            <p><%= t('dashboard.tr.batch_connect_no_sessions') %></p>
           </div>
         <% else %>
           <%= render partial: "panel", collection: @sessions, as: :session %>
@@ -41,7 +41,7 @@
   <%- else -%>
     <div class="col-md-12">
       <div class="ood-appkit markdown">
-        <p><%= t('dashboard.generic_msg.batch_connect_no_apps') %></p>
+        <p><%= t('dashboard.tr.batch_connect_no_apps') %></p>
       </div>
     </div>
   <%- end -%>

--- a/app/views/batch_connect/shared/_app_menu.html.erb
+++ b/app/views/batch_connect/shared/_app_menu.html.erb
@@ -30,7 +30,7 @@
     render(
         partial: "batch_connect/shared/app_list",
         locals: {
-          title: "#{app_group.title}" + t('dashboard.batch_connect.sandbox'),
+          title: "#{app_group.title}" + t('dashboard.generic_msg.batch_connect_sandbox'),
           apps: app_group.apps,
           current_url: local_assigns[:current_url],
           style: "ood-burgundy"

--- a/app/views/batch_connect/shared/_app_menu.html.erb
+++ b/app/views/batch_connect/shared/_app_menu.html.erb
@@ -30,7 +30,7 @@
     render(
         partial: "batch_connect/shared/app_list",
         locals: {
-          title: "#{app_group.title}" + t('dashboard.generic_msg.batch_connect_sandbox'),
+          title: "#{app_group.title}" + t('dashboard.tr.batch_connect_sandbox'),
           apps: app_group.apps,
           current_url: local_assigns[:current_url],
           style: "ood-burgundy"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,13 +35,13 @@
             <%= render partial: 'layouts/nav/develop_dropdown' if Configuration.app_development_enabled? %>
             <%= render partial: "layouts/nav/help_dropdown" %>
           </ul>
-          <p class="navbar-text" data-toggle="popover" data-content="<%= t('dashboard.nav.user', username: @user.name) %>" data-placement="bottom" >
-            <i class="fas fa-user" title="<%= t('dashboard.nav.user', username: @user.name) %>"></i>
-            <span class="hidden-sm"><span class="hidden-md"> <%= t('dashboard.nav.user', username: @user.name) %></span>
+          <p class="navbar-text" data-toggle="popover" data-content="<%= t('dashboard.generic_msg.nav_user', username: @user.name) %>" data-placement="bottom" >
+            <i class="fas fa-user" title="<%= t('dashboard.generic_msg.nav_user', username: @user.name) %>"></i>
+            <span class="hidden-sm"><span class="hidden-md"> <%= t('dashboard.generic_msg.nav_user', username: @user.name) %></span>
           </p>
           <ul class="nav navbar-nav">
             <li>
-              <a href="/logout"><i class="fas fa-sign-out-alt"></i><span class="hidden-sm"> <%= t('dashboard.nav.logout') %></span></a>
+              <a href="/logout"><i class="fas fa-sign-out-alt"></i><span class="hidden-sm"> <%= t('dashboard.generic_msg.nav_logout') %></span></a>
             </li>
             <li>
           </ul>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,13 +35,13 @@
             <%= render partial: 'layouts/nav/develop_dropdown' if Configuration.app_development_enabled? %>
             <%= render partial: "layouts/nav/help_dropdown" %>
           </ul>
-          <p class="navbar-text" data-toggle="popover" data-content="<%= t('dashboard.generic_msg.nav_user', username: @user.name) %>" data-placement="bottom" >
-            <i class="fas fa-user" title="<%= t('dashboard.generic_msg.nav_user', username: @user.name) %>"></i>
-            <span class="hidden-sm"><span class="hidden-md"> <%= t('dashboard.generic_msg.nav_user', username: @user.name) %></span>
+          <p class="navbar-text" data-toggle="popover" data-content="<%= t('dashboard.tr.nav_user', username: @user.name) %>" data-placement="bottom" >
+            <i class="fas fa-user" title="<%= t('dashboard.tr.nav_user', username: @user.name) %>"></i>
+            <span class="hidden-sm"><span class="hidden-md"> <%= t('dashboard.tr.nav_user', username: @user.name) %></span>
           </p>
           <ul class="nav navbar-nav">
             <li>
-              <a href="/logout"><i class="fas fa-sign-out-alt"></i><span class="hidden-sm"> <%= t('dashboard.generic_msg.nav_logout') %></span></a>
+              <a href="/logout"><i class="fas fa-sign-out-alt"></i><span class="hidden-sm"> <%= t('dashboard.tr.nav_logout') %></span></a>
             </li>
             <li>
           </ul>

--- a/app/views/layouts/nav/_all_apps.html.erb
+++ b/app/views/layouts/nav/_all_apps.html.erb
@@ -1,5 +1,5 @@
 <li title="<%= t('dashboard.nav.all_apps') %>">
   <a target="_self" href="<%= apps_index_path %>">
-    <i class="fas fa-th"></i><span class="hidden-sm hidden-md hidden-md-nav"> <%= t('dashboard.nav.all_apps') %></span>
+    <i class="fas fa-th"></i><span class="hidden-sm hidden-md hidden-md-nav"> <%= t('dashboard.generic_msg.nav_all_apps') %></span>
   </a>
 </li>

--- a/app/views/layouts/nav/_all_apps.html.erb
+++ b/app/views/layouts/nav/_all_apps.html.erb
@@ -1,5 +1,5 @@
 <li title="<%= t('dashboard.nav.all_apps') %>">
   <a target="_self" href="<%= apps_index_path %>">
-    <i class="fas fa-th"></i><span class="hidden-sm hidden-md hidden-md-nav"> <%= t('dashboard.generic_msg.nav_all_apps') %></span>
+    <i class="fas fa-th"></i><span class="hidden-sm hidden-md hidden-md-nav"> <%= t('dashboard.tr.nav_all_apps') %></span>
   </a>
 </li>

--- a/app/views/layouts/nav/_develop_dropdown.html.erb
+++ b/app/views/layouts/nav/_develop_dropdown.html.erb
@@ -1,10 +1,10 @@
-<li class="dropdown" title="<%= t('dashboard.nav.develop.title') %>">
+<li class="dropdown" title="<%= t('dashboard.generic_msg.nav_develop_title') %>">
   <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-    <i class="fas fa-code"></i><span class="hidden-sm hidden-sm-nav"> <%= t('dashboard.nav.develop.title') %></span><span class="caret"></span>
+    <i class="fas fa-code"></i><span class="hidden-sm hidden-sm-nav"> <%= t('dashboard.generic_msg.nav_develop_title') %></span><span class="caret"></span>
   </a>
   <ul class="dropdown-menu">
-    <%= nav_link(t('dashboard.nav.restart_server'), "sync", restart_url) %>
-    <%= nav_link(t('dashboard.nav.develop.docs'), "book", Configuration.developer_docs_url, target: "_blank") %>
+    <%= nav_link(t('dashboard.generic_msg.nav_restart_server'), "sync", restart_url) %>
+    <%= nav_link(t('dashboard.generic_msg.nav_develop_docs'), "book", Configuration.developer_docs_url, target: "_blank") %>
     <%= nav_link(products_title(:dev), "cog", products_path(type: "dev")) %>
     <% if Configuration.app_sharing_enabled? %>
       <%= nav_link(products_title(:usr), "share-alt", products_path(type: "usr")) %>

--- a/app/views/layouts/nav/_develop_dropdown.html.erb
+++ b/app/views/layouts/nav/_develop_dropdown.html.erb
@@ -1,10 +1,10 @@
-<li class="dropdown" title="<%= t('dashboard.generic_msg.nav_develop_title') %>">
+<li class="dropdown" title="<%= t('dashboard.tr.nav_develop_title') %>">
   <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-    <i class="fas fa-code"></i><span class="hidden-sm hidden-sm-nav"> <%= t('dashboard.generic_msg.nav_develop_title') %></span><span class="caret"></span>
+    <i class="fas fa-code"></i><span class="hidden-sm hidden-sm-nav"> <%= t('dashboard.tr.nav_develop_title') %></span><span class="caret"></span>
   </a>
   <ul class="dropdown-menu">
-    <%= nav_link(t('dashboard.generic_msg.nav_restart_server'), "sync", restart_url) %>
-    <%= nav_link(t('dashboard.generic_msg.nav_develop_docs'), "book", Configuration.developer_docs_url, target: "_blank") %>
+    <%= nav_link(t('dashboard.tr.nav_restart_server'), "sync", restart_url) %>
+    <%= nav_link(t('dashboard.tr.nav_develop_docs'), "book", Configuration.developer_docs_url, target: "_blank") %>
     <%= nav_link(products_title(:dev), "cog", products_path(type: "dev")) %>
     <% if Configuration.app_sharing_enabled? %>
       <%= nav_link(products_title(:usr), "share-alt", products_path(type: "usr")) %>

--- a/app/views/layouts/nav/_help_dropdown.html.erb
+++ b/app/views/layouts/nav/_help_dropdown.html.erb
@@ -3,10 +3,10 @@
     <i class="fas fa-question-circle"></i><span class="hidden-sm hidden-sm-nav"> <%= t('dashboard.tr.nav_help_title') %></span><span class="caret"></span>
   </a>
   <ul class="dropdown-menu">
-    <%= nav_link(t('dashboard.site.nav_help_support'), "question-circle", support_url, target: "_blank") %>
-    <%= nav_link(t('dashboard.site.nav_help_docs'), "info-circle", docs_url, target: "_blank") %>
-    <%= nav_link(t('dashboard.site.nav_help_change_password'), "key", passwd_url, target: "_blank") %>
-    <%= nav_link(t('dashboard.site.nav_help_two_factor'), "mobile-alt", configure_2fa_url, target: "_blank") %>
+    <%= nav_link(t('dashboard.nav_help_support'), "question-circle", support_url, target: "_blank") %>
+    <%= nav_link(t('dashboard.nav_help_docs'), "info-circle", docs_url, target: "_blank") %>
+    <%= nav_link(t('dashboard.nav_help_change_password'), "key", passwd_url, target: "_blank") %>
+    <%= nav_link(t('dashboard.nav_help_two_factor'), "mobile-alt", configure_2fa_url, target: "_blank") %>
     <%= nav_link(t('dashboard.tr.nav_restart_server'), "sync", restart_url) %>
   </ul>
 </li>

--- a/app/views/layouts/nav/_help_dropdown.html.erb
+++ b/app/views/layouts/nav/_help_dropdown.html.erb
@@ -1,12 +1,12 @@
-<li class="dropdown" title="<%= t('dashboard.nav.help.title') %>" >
+<li class="dropdown" title="<%= t('dashboard.generic_msg.nav_help_title') %>" >
   <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-    <i class="fas fa-question-circle"></i><span class="hidden-sm hidden-sm-nav"> <%= t('dashboard.nav.help.title') %></span><span class="caret"></span>
+    <i class="fas fa-question-circle"></i><span class="hidden-sm hidden-sm-nav"> <%= t('dashboard.generic_msg.nav_help_title') %></span><span class="caret"></span>
   </a>
   <ul class="dropdown-menu">
-    <%= nav_link(t('dashboard.nav.help.support'), "question-circle", support_url, target: "_blank") %>
-    <%= nav_link(t('dashboard.nav.help.docs'), "info-circle", docs_url, target: "_blank") %>
-    <%= nav_link(t('dashboard.nav.help.change_password'), "key", passwd_url, target: "_blank") %>
-    <%= nav_link(t('dashboard.nav.help.two_factor'), "mobile-alt", configure_2fa_url, target: "_blank") %>
-    <%= nav_link(t('dashboard.nav.restart_server'), "sync", restart_url) %>
+    <%= nav_link(t('dashboard.site_specific.nav_help_support'), "question-circle", support_url, target: "_blank") %>
+    <%= nav_link(t('dashboard.site_specific.nav_help_docs'), "info-circle", docs_url, target: "_blank") %>
+    <%= nav_link(t('dashboard.site_specific.nav_help_change_password'), "key", passwd_url, target: "_blank") %>
+    <%= nav_link(t('dashboard.site_specific.nav_help_two_factor'), "mobile-alt", configure_2fa_url, target: "_blank") %>
+    <%= nav_link(t('dashboard.generic_msg.nav_restart_server'), "sync", restart_url) %>
   </ul>
 </li>

--- a/app/views/layouts/nav/_help_dropdown.html.erb
+++ b/app/views/layouts/nav/_help_dropdown.html.erb
@@ -1,12 +1,12 @@
-<li class="dropdown" title="<%= t('dashboard.generic_msg.nav_help_title') %>" >
+<li class="dropdown" title="<%= t('dashboard.tr.nav_help_title') %>" >
   <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-    <i class="fas fa-question-circle"></i><span class="hidden-sm hidden-sm-nav"> <%= t('dashboard.generic_msg.nav_help_title') %></span><span class="caret"></span>
+    <i class="fas fa-question-circle"></i><span class="hidden-sm hidden-sm-nav"> <%= t('dashboard.tr.nav_help_title') %></span><span class="caret"></span>
   </a>
   <ul class="dropdown-menu">
-    <%= nav_link(t('dashboard.site_specific.nav_help_support'), "question-circle", support_url, target: "_blank") %>
-    <%= nav_link(t('dashboard.site_specific.nav_help_docs'), "info-circle", docs_url, target: "_blank") %>
-    <%= nav_link(t('dashboard.site_specific.nav_help_change_password'), "key", passwd_url, target: "_blank") %>
-    <%= nav_link(t('dashboard.site_specific.nav_help_two_factor'), "mobile-alt", configure_2fa_url, target: "_blank") %>
-    <%= nav_link(t('dashboard.generic_msg.nav_restart_server'), "sync", restart_url) %>
+    <%= nav_link(t('dashboard.site.nav_help_support'), "question-circle", support_url, target: "_blank") %>
+    <%= nav_link(t('dashboard.site.nav_help_docs'), "info-circle", docs_url, target: "_blank") %>
+    <%= nav_link(t('dashboard.site.nav_help_change_password'), "key", passwd_url, target: "_blank") %>
+    <%= nav_link(t('dashboard.site.nav_help_two_factor'), "mobile-alt", configure_2fa_url, target: "_blank") %>
+    <%= nav_link(t('dashboard.tr.nav_restart_server'), "sync", restart_url) %>
   </ul>
 </li>

--- a/app/views/layouts/nav/_sessions.html.erb
+++ b/app/views/layouts/nav/_sessions.html.erb
@@ -1,5 +1,5 @@
-<li title="<%= t('dashboard.generic_msg.breadcrumbs_my_sessions') %>">
+<li title="<%= t('dashboard.tr.breadcrumbs_my_sessions') %>">
   <a target="_self" href="<%= batch_connect_sessions_path %>">
-    <i class="fas fa-window-restore"></i><span class="hidden-sm hidden-md hidden-md-nav"> <%= t('dashboard.generic_msg.nav_sessions') %></span>
+    <i class="fas fa-window-restore"></i><span class="hidden-sm hidden-md hidden-md-nav"> <%= t('dashboard.tr.nav_sessions') %></span>
   </a>
 </li>

--- a/app/views/layouts/nav/_sessions.html.erb
+++ b/app/views/layouts/nav/_sessions.html.erb
@@ -1,5 +1,5 @@
-<li title="<%= t('dashboard.breadcrumbs.my_sessions') %>">
+<li title="<%= t('dashboard.generic_msg.breadcrumbs_my_sessions') %>">
   <a target="_self" href="<%= batch_connect_sessions_path %>">
-    <i class="fas fa-window-restore"></i><span class="hidden-sm hidden-md hidden-md-nav"> <%= t('dashboard.nav.sessions') %></span>
+    <i class="fas fa-window-restore"></i><span class="hidden-sm hidden-md hidden-md-nav"> <%= t('dashboard.generic_msg.nav_sessions') %></span>
   </a>
 </li>

--- a/app/views/shared/_insufficient_quota_resource.html.erb
+++ b/app/views/shared/_insufficient_quota_resource.html.erb
@@ -1,19 +1,15 @@
 <h4>
-  <%= t(  'dashboard.quota.warning_header_html',
-          path_tag: link_to(  "<strong>#{quota.path}</strong>".html_safe,
-                              OodAppkit.files.url(path: quota.path).to_s,
-                              class: "text-danger",
-                              target: "_blank"
-                            )
-        )
-  %>
+  <%= t('dashboard.site_specific.quota_warning_prefix_html') %>
+  <%= link_to OodAppkit.files.url(path: quota.path).to_s, class: "text-danger", target: "_blank" do %>
+    <strong><%= quota.path %></strong>
+  <%- end -%>
   <small class="pull-right hidden-xs hidden-sm">
-    <%= t('dashboard.quota.reload_message') %>
+    <%= t('dashboard.site_specific.quota_reload_message') %>
   </small>
 </h4>
 <ul class="list-unstyled">
   <li>
-    <%= quota.to_s %><%= ". #{t('dashboard.quota.additional_message')}" %>
+    <%= quota.to_s %><%= ". #{t('dashboard.site_specific.quota_additional_message')}" %>
   </li>
   <li>
     <%=

--- a/app/views/shared/_insufficient_quota_resource.html.erb
+++ b/app/views/shared/_insufficient_quota_resource.html.erb
@@ -1,15 +1,15 @@
 <h4>
-  <%= t('dashboard.site_specific.quota_warning_prefix_html') %>
+  <%= t('dashboard.site.quota_warning_prefix_html') %>
   <%= link_to OodAppkit.files.url(path: quota.path).to_s, class: "text-danger", target: "_blank" do %>
     <strong><%= quota.path %></strong>
   <%- end -%>
   <small class="pull-right hidden-xs hidden-sm">
-    <%= t('dashboard.site_specific.quota_reload_message') %>
+    <%= t('dashboard.site.quota_reload_message') %>
   </small>
 </h4>
 <ul class="list-unstyled">
   <li>
-    <%= quota.to_s %><%= ". #{t('dashboard.site_specific.quota_additional_message')}" %>
+    <%= quota.to_s %><%= ". #{t('dashboard.site.quota_additional_message')}" %>
   </li>
   <li>
     <%=

--- a/app/views/shared/_insufficient_quota_resource.html.erb
+++ b/app/views/shared/_insufficient_quota_resource.html.erb
@@ -1,15 +1,15 @@
 <h4>
-  <%= t('dashboard.site.quota_warning_prefix_html') %>
+  <%= t('dashboard.quota_warning_prefix_html') %>
   <%= link_to OodAppkit.files.url(path: quota.path).to_s, class: "text-danger", target: "_blank" do %>
     <strong><%= quota.path %></strong>
   <%- end -%>
   <small class="pull-right hidden-xs hidden-sm">
-    <%= t('dashboard.site.quota_reload_message') %>
+    <%= t('dashboard.quota_reload_message') %>
   </small>
 </h4>
 <ul class="list-unstyled">
   <li>
-    <%= quota.to_s %><%= ". #{t('dashboard.site.quota_additional_message')}" %>
+    <%= quota.to_s %><%= ". #{t('dashboard.quota_additional_message')}" %>
   </li>
   <li>
     <%=

--- a/app/views/shared/_welcome.html.erb
+++ b/app/views/shared/_welcome.html.erb
@@ -1,1 +1,1 @@
-<%= t('dashboard.site_specific.welcome_html', logo_img_tag: Configuration.logo_img? ? logo_image_tag(Configuration.logo_img) : "") %>
+<%= t('dashboard.site.welcome_html', logo_img_tag: Configuration.logo_img? ? logo_image_tag(Configuration.logo_img) : "") %>

--- a/app/views/shared/_welcome.html.erb
+++ b/app/views/shared/_welcome.html.erb
@@ -1,1 +1,1 @@
-<%= t('dashboard.site.welcome_html', logo_img_tag: Configuration.logo_img? ? logo_image_tag(Configuration.logo_img) : "") %>
+<%= t('dashboard.welcome_html', logo_img_tag: Configuration.logo_img? ? logo_image_tag(Configuration.logo_img) : "") %>

--- a/app/views/shared/_welcome.html.erb
+++ b/app/views/shared/_welcome.html.erb
@@ -1,1 +1,1 @@
-<%= t('dashboard.welcome_html', logo_img_tag: Configuration.logo_img? ? logo_image_tag(Configuration.logo_img) : "") %>
+<%= t('dashboard.site_specific.welcome_html', logo_img_tag: Configuration.logo_img? ? logo_image_tag(Configuration.logo_img) : "") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,117 +21,229 @@
 
 en:
   dashboard:
-    welcome_html: |
-      %{logo_img_tag}
-      <p class="lead">OnDemand provides an integrated, single access point for all of your HPC resources.</p>
-    motd_title: "Message of the Day"
-    breadcrumbs:
-      home: "Home"
-      my_sessions: "My Interactive Sessions"
-      all_apps: "All Apps"
-    restart_msg_html: |
-      Your group membership has changed, which affects your access to apps. Your dashboard should restart automatically. 
-      If it doesn't please, click: <a href="%{restart_url}">restart web server</a>.
-    nav:
-      sessions: "My Interactive Sessions"
-      all_apps: "All Apps"
-      develop:
-        title: "Develop"
-        docs: "Developer Documentation"
-      help:
-        title: "Help"
-        change_password: "Change HPC Password"
-        support: "Contact Support"
-        docs: "Online Documentation"
-        two_factor: "Configure Two-Factor Authentication"
-      restart_server: "Restart Web Server"
-      user: "Logged in as %{username}"
-      logout: "Log Out"
-    batch_connect:
-      no_sessions: "You have no active sessions."
-      no_apps: "There are no available Interactive Apps."
-      sandbox: " [Sandbox]"
-      sessions:
-        data_html: |
-          * The %{title} session data for this session can be accessed 
-          under the %{data_link_tag}.
-        staged_root: "staged root directory"
-        status:
-          bad: |
-            Your session has entered a bad state. Feel free to contact support for 
-            further information.
-          missing_connection: |
-            This app is missing information required to establish a connection. Please 
-            contact support if you see this message.
-          queued: |
-            Please be patient as your job currently sits in queue. The wait time depends 
-            on the number of cores as well as time requested.
-          starting: |
-            Your session is currently starting... Please be patient as this process can 
-            take a few minutes.
-        novnc:
-          launch: "Launch noVNC in New Tab"
-          view_only: "View Only (Share-able Link)"
-        stats:
-          created_at: "Created at:"
-          time_remaining: "Time Remaining:"
-          time_used: "Time Used:"
-          time_requested: "Time Requested:"
-          host: "Host:"
-          undetermined_host: "Undetermined"
-          session_id: "Session ID:"
-        status_blurb:
-          create_success: "Session was successfully created."
-          delete_success: "Session was successfully deleted."
-          delete_failure: "Session failed to be deleted."
-        delete:
-          title: "Delete"
-          hover: "Delete Session"
-          confirm: "Are you sure?"
-        errors:
-          submission: "Failed to submit session with the following error:"
-          staging: "Failed to stage the template with the following error:"
-      form:
-        launch: "Launch"
-        reset_resolution: "Reset Resolution"
-        session_data_html: |
-          * All %{title} session data is generated and stored under 
-          the user's home directory in the corresponding %{data_link_tag}.
-        data_root: "data root directory"
-    quota:
-      warning_header_html: "Quota limit warning for %{path_tag}"
-      reload_message: "Reload page to see updated quota. Quotas are updated every 5 minutes."
-      additional_message: "Consider deleting or archiving files to free up disk space."
-      file: "Using %{used} files of quota %{available} files"
-      file_shared: "(%{used_exclusive} files are yours)"
-      block: "Using %{used} of quota %{available}"
-      block_shared: "(%{used_exclusive} are yours)"
-    sharing:
-      welcome_msg_html: |
-        Cluster access applications are available from the dropdown menus in the navbar above.
-        <br>Custom shared apps are available below.
-      no_shared_apps_html: |
-        <strong>No custom shared apps available.</strong>
-      support_msg_html: |
-        If you don't see the app you are looking for, please
-        <a href="%{support_url}">contact support</a>.
-      catalog_msg_html: |
-        <br>A subset of the apps available can be viewed on the %{catalog_link_tag}.
-      catalog_title: "App Catalog"
-    apps:
-      system_apps_title: "System Apps"
-      shared_apps_title: "Shared Apps"
-      setup_failure_html: |
+    site_specific:
+      batch_connect_sessions_status_bad: "Your session has entered a bad state. Feel free to contact support for
+            further information.👍"
+      batch_connect_sessions_status_missing_connection: |
+        This app is missing information required to establish a connection. Please
+        contact support if you see this message.👍
+      batch_connect_sessions_status_queued: |
+        Please be patient as your job currently sits in queue. The wait time depends
+        on the number of cores as well as time requested.👍
+
+      nav_help_change_password: "Change HPC Password👍"
+      nav_help_docs: "Online Documentation👍"
+      nav_help_support: "Contact Support👍"
+      nav_help_two_factor: "Configure Two-Factor Authentication👍"
+
+      quota_additional_message: "Consider deleting or archiving files to free up disk space.👍"
+      quota_reload_message: "Reload page to see updated quota. Quotas are updated every 5 minutes.👍"
+      quota_warning_prefix_html: "Quota limit warning for👍"
+
+      welcome_html: |
+        %{logo_img_tag}
+        <p class="lead">OnDemand provides an integrated, single access point for all of your HPC resources.👍</p>
+
+    generic_msg:
+      apps_setup_failure_html: |
         <h2>A problem occurred while initializing your data for this app.</h2>
         <p class="lead">
-          At your own risk you can still <a href="%{app_url}">open the app</a> 
+          At your own risk you can still <a href="%{app_url}">open the app</a>
           or you can just go <a href="%{home_url}">back to the dashboard</a>
         </p>
         <p>
           Share this with the developer of your app:
-          The setup production script is supposed to be idempotent and is run each time 
+          The setup production script is supposed to be idempotent and is run each time
           the user opens the app through the dashboard.</p>
         <h4>Exception: %{exception_class}</h4>
         <pre>%{exception_message}</pre>
         <h4>Stack trace:</h4>
-        <pre>%{exception_trace}</pre>
+        <pre>%{exception_trace}</pre>👍
+      apps_system_apps_title: "System Apps👍"
+
+      batch_connect_form_data_root: "data root directory"
+      batch_connect_form_launch: "Launch👍"
+      batch_connect_form_reset_resolution: "Reset Resolution👍"
+      batch_connect_form_session_data_html: |
+        * The %{title} session data for this session can be accessed
+          under the %{data_link_tag}.👍
+      batch_connect_no_apps: "There are no available Interactive Apps.👍"
+      batch_connect_no_sessions: "You have no active sessions.👍"
+      batch_connect_sandbox: " [Sandbox]👍"
+      batch_connect_sessions_data_html: |
+        * The %{title} session data for this session can be accessed
+        under the %{data_link_tag}.👍
+      batch_connect_sessions_delete_confirm: "Are you sure?👍"
+      batch_connect_sessions_delete_hover: "Delete Session👍"
+      batch_connect_sessions_delete_title: "Delete👍"
+      batch_connect_sessions_errors_staging: "Failed to stage the template with the following error:👍"
+      batch_connect_sessions_errors_submission: "Failed to submit session with the following error:👍"
+      batch_connect_sessions_novnc_launch: "Launch noVNC in New Tab👍"
+      batch_connect_sessions_novnc_view_only: "View Only (Share-able Link)👍"
+      batch_connect_sessions_staged_root: "staged root directory👍"
+      batch_connect_sessions_stats_created_at: "Created at:👍"
+      batch_connect_sessions_stats_host: "Host:👍"
+      batch_connect_sessions_stats_session_id: "Session ID:👍"
+      batch_connect_sessions_stats_time_remaining: "Time Remaining:👍"
+      batch_connect_sessions_stats_time_requested: "Time Requested:👍"
+      batch_connect_sessions_stats_time_used: "Time Used:👍"
+      batch_connect_sessions_stats_undetermined_host: "Undetermined👍"
+      batch_connect_sessions_status_blurb_create_success: "Session was successfully created.👍"
+      batch_connect_sessions_status_blurb_delete_failure: "Failed to delete session.👍"
+      batch_connect_sessions_status_blurb_delete_success: "Session was successfully deleted.👍"
+      batch_connect_sessions_status_starting: |
+        Your session is currently starting... Please be patient as this process can
+        take a few minutes.👍
+
+      breadcrumbs_all_apps: "All Apps👍"
+      breadcrumbs_home: "Home"
+      breadcrumbs_home: "Home👍"
+      breadcrumbs_my_sessions: "My Interactive Sessions👍"
+      breadcrumbs_my_sessions: "My Interactive Sessions👍"
+
+      nav_all_apps: "All Apps👍"
+      nav_develop_docs: "Developer Documentation👍"
+      nav_develop_my_sandbox_apps_dev: "My Sandbox Apps (Development)👍"
+      nav_develop_my_sandbox_apps_prod: "My Sandbox Apps (Production)👍"
+      nav_develop_title: "Develop👍"
+      nav_help_title: "Help👍"
+      nav_logout: "Log Out👍"
+      nav_restart_server: "Restart Web Server👍"
+      nav_restart_server: "Restart Web Server👍"
+      nav_sessions: "My Interactive Sessions👍"  # Note duplication with breadcrumbs_my_sessions
+      nav_user: "Logged in as %{username}👍"
+
+      quota_block: "Using %{used} of quota %{available}👍"
+      quota_block_shared: "(%{used_exclusive} are yours)👍"
+      quota_file: "Using %{used} files of quota %{available} files👍"
+      quota_file_shared: "(%{used_exclusive} files are yours)👍"
+
+      restart_msg_html: |
+        Your group membership has changed, which affects your access to apps. Your dashboard should restart automatically.
+        If it doesn't please, click: <a href="%{restart_url}">restart web server</a>.👍
+
+      shared_apps_title: "Shared Apps👍"
+      sharing_catalog_title: "App Catalog👍"
+      sharing_no_shared_apps_html: |
+        <strong>No custom shared apps available.</strong>👍
+      sharing_support_msg_html: |
+        <br>A subset of the apps available can be viewed on the %{catalog_link_tag}.👍
+      sharing_welcome_msg_html: |
+        Cluster access applications are available from the dropdown menus in the navbar above.
+        <br>Custom shared apps are available below.👍
+
+# # ===== ORIGINAL ===== #
+#     welcome_html: |
+#       %{logo_img_tag}
+#       <p class="lead">OnDemand provides an integrated, single access point for all of your HPC resources.</p>
+#     motd_title: "Message of the Day"
+#     breadcrumbs:
+#       home: "Home"
+#       my_sessions: "My Interactive Sessions"
+#       all_apps: "All Apps"
+#     restart_msg_html: |
+#       Your group membership has changed, which affects your access to apps. Your dashboard should restart automatically.
+#       If it doesn't please, click: <a href="%{restart_url}">restart web server</a>.
+#     nav:
+#       sessions: "My Interactive Sessions"
+#       all_apps: "All Apps"
+#       develop:
+#         title: "Develop"
+#         docs: "Developer Documentation"
+#       help:
+#         title: "Help"
+#         change_password: "Change HPC Password"
+#         support: "Contact Support"
+#         docs: "Online Documentation"
+#         two_factor: "Configure Two-Factor Authentication"
+#       restart_server: "Restart Web Server"
+#       user: "Logged in as %{username}"
+#       logout: "Log Out"
+#     batch_connect:
+#       no_sessions: "You have no active sessions."
+#       no_apps: "There are no available Interactive Apps."
+#       sandbox: " [Sandbox]"
+#       sessions:
+#         data_html: |
+#           * The %{title} session data for this session can be accessed
+#           under the %{data_link_tag}.
+#         staged_root: "staged root directory"
+#         status:
+#           bad: |
+#             Your session has entered a bad state. Feel free to contact support for
+#             further information.
+#           missing_connection: |
+#             This app is missing information required to establish a connection. Please
+#             contact support if you see this message.
+#           queued: |
+#             Please be patient as your job currently sits in queue. The wait time depends
+#             on the number of cores as well as time requested.
+#           starting: |
+#             Your session is currently starting... Please be patient as this process can
+#             take a few minutes.
+#         novnc:
+#           launch: "Launch noVNC in New Tab"
+#           view_only: "View Only (Share-able Link)"
+#         stats:
+#           created_at: "Created at:"
+#           time_remaining: "Time Remaining:"
+#           time_used: "Time Used:"
+#           time_requested: "Time Requested:"
+#           host: "Host:"
+#           undetermined_host: "Undetermined"
+#           session_id: "Session ID:"
+#         status_blurb:
+#           create_success: "Session was successfully created."
+#           delete_success: "Session was successfully deleted."
+#           delete_failure: "Session failed to be deleted."
+#         delete:
+#           title: "Delete"
+#           hover: "Delete Session"
+#           confirm: "Are you sure?"
+#         errors:
+#           submission: "Failed to submit session with the following error:"
+#           staging: "Failed to stage the template with the following error:"
+#       form:
+#         launch: "Launch"
+#         reset_resolution: "Reset Resolution"
+#         session_data_html: |
+#           * All %{title} session data is generated and stored under
+#           the user's home directory in the corresponding %{data_link_tag}.
+#         data_root: "data root directory"
+#     quota:
+#       warning_header_html: "Quota limit warning for %{path_tag}"
+#       reload_message: "Reload page to see updated quota. Quotas are updated every 5 minutes."
+#       additional_message: "Consider deleting or archiving files to free up disk space."
+#       file: "Using %{used} files of quota %{available} files"
+#       file_shared: "(%{used_exclusive} files are yours)"
+#       block: "Using %{used} of quota %{available}"
+#       block_shared: "(%{used_exclusive} are yours)"
+#     sharing:
+#       welcome_msg_html: |
+#         Cluster access applications are available from the dropdown menus in the navbar above.
+#         <br>Custom shared apps are available below.
+#       no_shared_apps_html: |
+#         <strong>No custom shared apps available.</strong>
+#       support_msg_html: |
+#         If you don't see the app you are looking for, please
+#         <a href="%{support_url}">contact support</a>.
+#       catalog_msg_html: |
+#         <br>A subset of the apps available can be viewed on the %{catalog_link_tag}.
+#       catalog_title: "App Catalog"
+#     apps:
+#       system_apps_title: "System Apps"
+#       shared_apps_title: "Shared Apps"
+#       setup_failure_html: |
+#         <h2>A problem occurred while initializing your data for this app.</h2>
+#         <p class="lead">
+#           At your own risk you can still <a href="%{app_url}">open the app</a>
+#           or you can just go <a href="%{home_url}">back to the dashboard</a>
+#         </p>
+#         <p>
+#           Share this with the developer of your app:
+#           The setup production script is supposed to be idempotent and is run each time
+#           the user opens the app through the dashboard.</p>
+#         <h4>Exception: %{exception_class}</h4>
+#         <pre>%{exception_message}</pre>
+#         <h4>Stack trace:</h4>
+#         <pre>%{exception_trace}</pre>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,7 +21,7 @@
 
 en:
   dashboard:
-    site_specific:
+    site:
       batch_connect_sessions_status_bad: "Your session has entered a bad state. Feel free to contact support for
             further information."
       batch_connect_sessions_status_missing_connection: |
@@ -44,7 +44,7 @@ en:
         %{logo_img_tag}
         <p class="lead">OnDemand provides an integrated, single access point for all of your HPC resources.</p>
 
-    generic_msg:
+    tr:
       apps_setup_failure_html: |
         <h2>A problem occurred while initializing your data for this app.</h2>
         <p class="lead">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,28 +21,27 @@
 
 en:
   dashboard:
-    site:
-      batch_connect_sessions_status_bad: "Your session has entered a bad state. Feel free to contact support for
-            further information."
-      batch_connect_sessions_status_missing_connection: |
-        This app is missing information required to establish a connection. Please
-        contact support if you see this message.
-      batch_connect_sessions_status_queued: |
-        Please be patient as your job currently sits in queue. The wait time depends
-        on the number of cores as well as time requested.
+    batch_connect_sessions_status_bad: "Your session has entered a bad state. Feel free to contact support for
+          further information."
+    batch_connect_sessions_status_missing_connection: |
+      This app is missing information required to establish a connection. Please
+      contact support if you see this message.
+    batch_connect_sessions_status_queued: |
+      Please be patient as your job currently sits in queue. The wait time depends
+      on the number of cores as well as time requested.
 
-      nav_help_change_password: "Change HPC Password"
-      nav_help_docs: "Online Documentation"
-      nav_help_support: "Contact Support"
-      nav_help_two_factor: "Configure Two-Factor Authentication"
+    nav_help_change_password: "Change HPC Password"
+    nav_help_docs: "Online Documentation"
+    nav_help_support: "Contact Support"
+    nav_help_two_factor: "Configure Two-Factor Authentication"
 
-      quota_additional_message: "Consider deleting or archiving files to free up disk space."
-      quota_reload_message: "Reload page to see updated quota. Quotas are updated every 5 minutes."
-      quota_warning_prefix_html: "Quota limit warning for"
+    quota_additional_message: "Consider deleting or archiving files to free up disk space."
+    quota_reload_message: "Reload page to see updated quota. Quotas are updated every 5 minutes."
+    quota_warning_prefix_html: "Quota limit warning for"
 
-      welcome_html: |
-        %{logo_img_tag}
-        <p class="lead">OnDemand provides an integrated, single access point for all of your HPC resources.</p>
+    welcome_html: |
+      %{logo_img_tag}
+      <p class="lead">OnDemand provides an integrated, single access point for all of your HPC resources.</p>
 
     tr:
       apps_setup_failure_html: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,26 +23,26 @@ en:
   dashboard:
     site_specific:
       batch_connect_sessions_status_bad: "Your session has entered a bad state. Feel free to contact support for
-            further information.👍"
+            further information."
       batch_connect_sessions_status_missing_connection: |
         This app is missing information required to establish a connection. Please
-        contact support if you see this message.👍
+        contact support if you see this message.
       batch_connect_sessions_status_queued: |
         Please be patient as your job currently sits in queue. The wait time depends
-        on the number of cores as well as time requested.👍
+        on the number of cores as well as time requested.
 
-      nav_help_change_password: "Change HPC Password👍"
-      nav_help_docs: "Online Documentation👍"
-      nav_help_support: "Contact Support👍"
-      nav_help_two_factor: "Configure Two-Factor Authentication👍"
+      nav_help_change_password: "Change HPC Password"
+      nav_help_docs: "Online Documentation"
+      nav_help_support: "Contact Support"
+      nav_help_two_factor: "Configure Two-Factor Authentication"
 
-      quota_additional_message: "Consider deleting or archiving files to free up disk space.👍"
-      quota_reload_message: "Reload page to see updated quota. Quotas are updated every 5 minutes.👍"
-      quota_warning_prefix_html: "Quota limit warning for👍"
+      quota_additional_message: "Consider deleting or archiving files to free up disk space."
+      quota_reload_message: "Reload page to see updated quota. Quotas are updated every 5 minutes."
+      quota_warning_prefix_html: "Quota limit warning for"
 
       welcome_html: |
         %{logo_img_tag}
-        <p class="lead">OnDemand provides an integrated, single access point for all of your HPC resources.👍</p>
+        <p class="lead">OnDemand provides an integrated, single access point for all of your HPC resources.</p>
 
     generic_msg:
       apps_setup_failure_html: |
@@ -58,192 +58,76 @@ en:
         <h4>Exception: %{exception_class}</h4>
         <pre>%{exception_message}</pre>
         <h4>Stack trace:</h4>
-        <pre>%{exception_trace}</pre>👍
-      apps_system_apps_title: "System Apps👍"
+        <pre>%{exception_trace}</pre>
+      apps_system_apps_title: "System Apps"
 
       batch_connect_form_data_root: "data root directory"
-      batch_connect_form_launch: "Launch👍"
-      batch_connect_form_reset_resolution: "Reset Resolution👍"
+      batch_connect_form_launch: "Launch"
+      batch_connect_form_reset_resolution: "Reset Resolution"
       batch_connect_form_session_data_html: |
         * The %{title} session data for this session can be accessed
-          under the %{data_link_tag}.👍
-      batch_connect_no_apps: "There are no available Interactive Apps.👍"
-      batch_connect_no_sessions: "You have no active sessions.👍"
-      batch_connect_sandbox: " [Sandbox]👍"
+          under the %{data_link_tag}.
+      batch_connect_no_apps: "There are no available Interactive Apps."
+      batch_connect_no_sessions: "You have no active sessions."
+      batch_connect_sandbox: " [Sandbox]"
       batch_connect_sessions_data_html: |
         * The %{title} session data for this session can be accessed
-        under the %{data_link_tag}.👍
-      batch_connect_sessions_delete_confirm: "Are you sure?👍"
-      batch_connect_sessions_delete_hover: "Delete Session👍"
-      batch_connect_sessions_delete_title: "Delete👍"
-      batch_connect_sessions_errors_staging: "Failed to stage the template with the following error:👍"
-      batch_connect_sessions_errors_submission: "Failed to submit session with the following error:👍"
-      batch_connect_sessions_novnc_launch: "Launch noVNC in New Tab👍"
-      batch_connect_sessions_novnc_view_only: "View Only (Share-able Link)👍"
-      batch_connect_sessions_staged_root: "staged root directory👍"
-      batch_connect_sessions_stats_created_at: "Created at:👍"
-      batch_connect_sessions_stats_host: "Host:👍"
-      batch_connect_sessions_stats_session_id: "Session ID:👍"
-      batch_connect_sessions_stats_time_remaining: "Time Remaining:👍"
-      batch_connect_sessions_stats_time_requested: "Time Requested:👍"
-      batch_connect_sessions_stats_time_used: "Time Used:👍"
-      batch_connect_sessions_stats_undetermined_host: "Undetermined👍"
-      batch_connect_sessions_status_blurb_create_success: "Session was successfully created.👍"
-      batch_connect_sessions_status_blurb_delete_failure: "Failed to delete session.👍"
-      batch_connect_sessions_status_blurb_delete_success: "Session was successfully deleted.👍"
+        under the %{data_link_tag}.
+      batch_connect_sessions_delete_confirm: "Are you sure?"
+      batch_connect_sessions_delete_hover: "Delete Session"
+      batch_connect_sessions_delete_title: "Delete"
+      batch_connect_sessions_errors_staging: "Failed to stage the template with the following error:"
+      batch_connect_sessions_errors_submission: "Failed to submit session with the following error:"
+      batch_connect_sessions_novnc_launch: "Launch noVNC in New Tab"
+      batch_connect_sessions_novnc_view_only: "View Only (Share-able Link)"
+      batch_connect_sessions_staged_root: "staged root directory"
+      batch_connect_sessions_stats_created_at: "Created at:"
+      batch_connect_sessions_stats_host: "Host:"
+      batch_connect_sessions_stats_session_id: "Session ID:"
+      batch_connect_sessions_stats_time_remaining: "Time Remaining:"
+      batch_connect_sessions_stats_time_requested: "Time Requested:"
+      batch_connect_sessions_stats_time_used: "Time Used:"
+      batch_connect_sessions_stats_undetermined_host: "Undetermined"
+      batch_connect_sessions_status_blurb_create_success: "Session was successfully created."
+      batch_connect_sessions_status_blurb_delete_failure: "Failed to delete session."
+      batch_connect_sessions_status_blurb_delete_success: "Session was successfully deleted."
       batch_connect_sessions_status_starting: |
         Your session is currently starting... Please be patient as this process can
-        take a few minutes.👍
+        take a few minutes.
 
-      breadcrumbs_all_apps: "All Apps👍"
+      breadcrumbs_all_apps: "All Apps"
       breadcrumbs_home: "Home"
-      breadcrumbs_home: "Home👍"
-      breadcrumbs_my_sessions: "My Interactive Sessions👍"
-      breadcrumbs_my_sessions: "My Interactive Sessions👍"
+      breadcrumbs_home: "Home"
+      breadcrumbs_my_sessions: "My Interactive Sessions"
+      breadcrumbs_my_sessions: "My Interactive Sessions"
 
-      nav_all_apps: "All Apps👍"
-      nav_develop_docs: "Developer Documentation👍"
-      nav_develop_my_sandbox_apps_dev: "My Sandbox Apps (Development)👍"
-      nav_develop_my_sandbox_apps_prod: "My Sandbox Apps (Production)👍"
-      nav_develop_title: "Develop👍"
-      nav_help_title: "Help👍"
-      nav_logout: "Log Out👍"
-      nav_restart_server: "Restart Web Server👍"
-      nav_restart_server: "Restart Web Server👍"
-      nav_sessions: "My Interactive Sessions👍"  # Note duplication with breadcrumbs_my_sessions
-      nav_user: "Logged in as %{username}👍"
+      nav_all_apps: "All Apps"
+      nav_develop_docs: "Developer Documentation"
+      nav_develop_my_sandbox_apps_dev: "My Sandbox Apps (Development)"
+      nav_develop_my_sandbox_apps_prod: "My Sandbox Apps (Production)"
+      nav_develop_title: "Develop"
+      nav_help_title: "Help"
+      nav_logout: "Log Out"
+      nav_restart_server: "Restart Web Server"
+      nav_restart_server: "Restart Web Server"
+      nav_sessions: "My Interactive Sessions"  # Note duplication with breadcrumbs_my_sessions
+      nav_user: "Logged in as %{username}"
 
-      quota_block: "Using %{used} of quota %{available}👍"
-      quota_block_shared: "(%{used_exclusive} are yours)👍"
-      quota_file: "Using %{used} files of quota %{available} files👍"
-      quota_file_shared: "(%{used_exclusive} files are yours)👍"
+      quota_block: "Using %{used} of quota %{available}"
+      quota_block_shared: "(%{used_exclusive} are yours)"
+      quota_file: "Using %{used} files of quota %{available} files"
+      quota_file_shared: "(%{used_exclusive} files are yours)"
 
       restart_msg_html: |
         Your group membership has changed, which affects your access to apps. Your dashboard should restart automatically.
-        If it doesn't please, click: <a href="%{restart_url}">restart web server</a>.👍
+        If it doesn't please, click: <a href="%{restart_url}">restart web server</a>.
 
-      shared_apps_title: "Shared Apps👍"
-      sharing_catalog_title: "App Catalog👍"
+      shared_apps_title: "Shared Apps"
+      sharing_catalog_title: "App Catalog"
       sharing_no_shared_apps_html: |
-        <strong>No custom shared apps available.</strong>👍
+        <strong>No custom shared apps available.</strong>
       sharing_support_msg_html: |
-        <br>A subset of the apps available can be viewed on the %{catalog_link_tag}.👍
+        <br>A subset of the apps available can be viewed on the %{catalog_link_tag}.
       sharing_welcome_msg_html: |
         Cluster access applications are available from the dropdown menus in the navbar above.
-        <br>Custom shared apps are available below.👍
-
-# # ===== ORIGINAL ===== #
-#     welcome_html: |
-#       %{logo_img_tag}
-#       <p class="lead">OnDemand provides an integrated, single access point for all of your HPC resources.</p>
-#     motd_title: "Message of the Day"
-#     breadcrumbs:
-#       home: "Home"
-#       my_sessions: "My Interactive Sessions"
-#       all_apps: "All Apps"
-#     restart_msg_html: |
-#       Your group membership has changed, which affects your access to apps. Your dashboard should restart automatically.
-#       If it doesn't please, click: <a href="%{restart_url}">restart web server</a>.
-#     nav:
-#       sessions: "My Interactive Sessions"
-#       all_apps: "All Apps"
-#       develop:
-#         title: "Develop"
-#         docs: "Developer Documentation"
-#       help:
-#         title: "Help"
-#         change_password: "Change HPC Password"
-#         support: "Contact Support"
-#         docs: "Online Documentation"
-#         two_factor: "Configure Two-Factor Authentication"
-#       restart_server: "Restart Web Server"
-#       user: "Logged in as %{username}"
-#       logout: "Log Out"
-#     batch_connect:
-#       no_sessions: "You have no active sessions."
-#       no_apps: "There are no available Interactive Apps."
-#       sandbox: " [Sandbox]"
-#       sessions:
-#         data_html: |
-#           * The %{title} session data for this session can be accessed
-#           under the %{data_link_tag}.
-#         staged_root: "staged root directory"
-#         status:
-#           bad: |
-#             Your session has entered a bad state. Feel free to contact support for
-#             further information.
-#           missing_connection: |
-#             This app is missing information required to establish a connection. Please
-#             contact support if you see this message.
-#           queued: |
-#             Please be patient as your job currently sits in queue. The wait time depends
-#             on the number of cores as well as time requested.
-#           starting: |
-#             Your session is currently starting... Please be patient as this process can
-#             take a few minutes.
-#         novnc:
-#           launch: "Launch noVNC in New Tab"
-#           view_only: "View Only (Share-able Link)"
-#         stats:
-#           created_at: "Created at:"
-#           time_remaining: "Time Remaining:"
-#           time_used: "Time Used:"
-#           time_requested: "Time Requested:"
-#           host: "Host:"
-#           undetermined_host: "Undetermined"
-#           session_id: "Session ID:"
-#         status_blurb:
-#           create_success: "Session was successfully created."
-#           delete_success: "Session was successfully deleted."
-#           delete_failure: "Session failed to be deleted."
-#         delete:
-#           title: "Delete"
-#           hover: "Delete Session"
-#           confirm: "Are you sure?"
-#         errors:
-#           submission: "Failed to submit session with the following error:"
-#           staging: "Failed to stage the template with the following error:"
-#       form:
-#         launch: "Launch"
-#         reset_resolution: "Reset Resolution"
-#         session_data_html: |
-#           * All %{title} session data is generated and stored under
-#           the user's home directory in the corresponding %{data_link_tag}.
-#         data_root: "data root directory"
-#     quota:
-#       warning_header_html: "Quota limit warning for %{path_tag}"
-#       reload_message: "Reload page to see updated quota. Quotas are updated every 5 minutes."
-#       additional_message: "Consider deleting or archiving files to free up disk space."
-#       file: "Using %{used} files of quota %{available} files"
-#       file_shared: "(%{used_exclusive} files are yours)"
-#       block: "Using %{used} of quota %{available}"
-#       block_shared: "(%{used_exclusive} are yours)"
-#     sharing:
-#       welcome_msg_html: |
-#         Cluster access applications are available from the dropdown menus in the navbar above.
-#         <br>Custom shared apps are available below.
-#       no_shared_apps_html: |
-#         <strong>No custom shared apps available.</strong>
-#       support_msg_html: |
-#         If you don't see the app you are looking for, please
-#         <a href="%{support_url}">contact support</a>.
-#       catalog_msg_html: |
-#         <br>A subset of the apps available can be viewed on the %{catalog_link_tag}.
-#       catalog_title: "App Catalog"
-#     apps:
-#       system_apps_title: "System Apps"
-#       shared_apps_title: "Shared Apps"
-#       setup_failure_html: |
-#         <h2>A problem occurred while initializing your data for this app.</h2>
-#         <p class="lead">
-#           At your own risk you can still <a href="%{app_url}">open the app</a>
-#           or you can just go <a href="%{home_url}">back to the dashboard</a>
-#         </p>
-#         <p>
-#           Share this with the developer of your app:
-#           The setup production script is supposed to be idempotent and is run each time
-#           the user opens the app through the dashboard.</p>
-#         <h4>Exception: %{exception_class}</h4>
-#         <pre>%{exception_message}</pre>
-#         <h4>Stack trace:</h4>
-#         <pre>%{exception_trace}</pre>
+        <br>Custom shared apps are available below.


### PR DESCRIPTION
There are still un-translated items on the Sandbox Apps page: `/pun/dev/ood-dashboard/admin/dev/products`.

Once translations are complete 👍 needs to be removed from the translation file, and the old commented-out translations deleted. Note that the thumbs are why the CI checks failed.