### PR TITLE
Display VERSION string for interactive app in web form

### DIFF
--- a/app/apps/ood_app.rb
+++ b/app/apps/ood_app.rb
@@ -253,9 +253,24 @@ class OodApp
     @passenger_railsdb_app = (passenger_rails_app? && has_gem?("sqlite3"))
   end
 
-
+  # @return [String] memoized version string
+  def version
+    @version ||= (version_from_file || version_from_git || "unknown").strip
+  end
 
   private
+
+  # @return [String, nil] version string from git describe, or nil if not git repo
+  def version_from_git
+    version = `( cd #{path}; git describe --always --tags 2>/dev/null )`
+    version.blank? ? nil : version
+  end
+
+  # @return [String, nil] version string from VERSION file, or nil if no file avail
+  def version_from_file
+    file = path.join("VERSION")
+    file.read if file.file?
+  end
 
   # Check if Gemfile and Gemfile.lock exists, and if the Gemfile.lock specs
   # include a gem with the specified name

--- a/app/apps/ood_app.rb
+++ b/app/apps/ood_app.rb
@@ -262,8 +262,8 @@ class OodApp
 
   # @return [String, nil] version string from git describe, or nil if not git repo
   def version_from_git
-    version = `( cd #{path}; git describe --always --tags 2>/dev/null )`
-    version.blank? ? nil : version
+    o, e, s = Open3.capture3('git', 'describe', '--always', '--tags', chdir: path.to_s)
+    s.success? ? o : nil
   end
 
   # @return [String, nil] version string from VERSION file, or nil if no file avail

--- a/app/models/batch_connect/app.rb
+++ b/app/models/batch_connect/app.rb
@@ -202,6 +202,17 @@ module BatchConnect
       @sub_app_list ||= build_sub_app_list
     end
 
+    # The version of the OodApp
+    # @return [String] the version
+    def version
+      @ood_app.version
+    end
+
+    # @return [String] the app name
+    def name
+      @ood_app.manifest.name.empty? ? @ood_app.name : @ood_app.manifest.name
+    end
+
     # Convert object to string
     # @return [String] the string describing this object
     def to_s

--- a/app/models/batch_connect/app.rb
+++ b/app/models/batch_connect/app.rb
@@ -208,11 +208,6 @@ module BatchConnect
       @ood_app.version
     end
 
-    # @return [String] the app name
-    def name
-      @ood_app.manifest.name.empty? ? @ood_app.name : @ood_app.manifest.name
-    end
-
     # Convert object to string
     # @return [String] the string describing this object
     def to_s

--- a/app/views/batch_connect/session_contexts/new.html.erb
+++ b/app/views/batch_connect/session_contexts/new.html.erb
@@ -49,7 +49,7 @@
   </div>
 
   <div class="col-md-6">
-    <h3><%= @app.title %></h3>
+    <h3><%= @app.title %> <small>version: <%= @app.version %></small></h3>
     <div class="ood-appkit markdown">
       <%= OodAppkit.markdown.render(@app.description).html_safe %>
 

--- a/app/views/batch_connect/session_contexts/new.html.erb
+++ b/app/views/batch_connect/session_contexts/new.html.erb
@@ -49,7 +49,12 @@
   </div>
 
   <div class="col-md-6">
-    <h3><%= @app.title %> <small>version: <%= @app.version %></small></h3>
+    <h3>
+      <%= @app.title %>
+      <% if @app.version != 'unknown' %>
+        <small>version: <%= @app.version %></small>
+      <% end %>
+    </h3>
     <div class="ood-appkit markdown">
       <%= OodAppkit.markdown.render(@app.description).html_safe %>
 

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -13,12 +13,7 @@
         <% end %>
       </div>
       <div class="col-md-6 col-sm-6">
-        <div class="pull-right">
-          <p>Dashboard version: <%= Configuration.version %></p>
-          <% if @app %>
-          <p><%= "#{@app.name} version: #{@app.version}" %></p>
-          <% end %>
-        </div>
+        <p class="pull-right">Dashboard version: <%= Configuration.version %></p>
       </div>
     </div>
   </div><!-- /.container -->

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -13,7 +13,12 @@
         <% end %>
       </div>
       <div class="col-md-6 col-sm-6">
-        <p class="pull-right">Dashboard version: <%= Configuration.version %></p>
+        <div class="pull-right">
+          <p>Dashboard version: <%= Configuration.version %></p>
+          <% if @app %>
+          <p><%= "#{@app.name} version: #{@app.version}" %></p>
+          <% end %>
+        </div>
       </div>
     </div>
   </div><!-- /.container -->


### PR DESCRIPTION
Prefers `VERSION` files, but falls back to `git describe --always --tags` otherwise.