### PR TITLE
Handle file not found error for announcements

### DIFF
--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -45,6 +45,8 @@ class Announcement
                   {}
                 end
       @opts.symbolize_keys.compact
+    rescue Errno::ENOENT  # File does not exist
+      @opts = {}
     rescue => e
       Rails.logger.warn "Error parsing announcement file '#{@path}': #{e.message}"
       @opts = {}


### PR DESCRIPTION
Stop showing the parse error warning in the logs when no announcement files exist by handling `Errno::ENOENT`.