### PR TITLE
Set production logging to use stderr

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
 
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
-
+  config.logger = Logger.new(STDERR)
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 


### PR DESCRIPTION
OnDemand does not give the user write permissions to the default Rails logging directory. Rails being magic gracefully warns us of this and falls back to logging to standard error and Nginx picks up responsibility for logging from there.

This commit formalizes our policy that logging to standard error is what we intend to do when in production.