### PR TITLE
Add ood version to footer

### DIFF
--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -16,3 +16,9 @@ ul.dropdown-menu .popover {
   -ms-word-break: break-all;
   word-break: break-word;
 }
+
+footer {
+  border-top: 1px solid #eee;
+  margin: 0px 15px;
+  padding-top: 30px;
+}

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -13,7 +13,7 @@
         <% end %>
       </div>
       <div class="col-md-6 col-sm-6">
-        <p class="pull-right">Dashboard version: <%= Configuration.version %></p>
+        <p class="pull-right">OnDemand version: <%= Configuration.ood_version %> | Dashboard version: <%= Configuration.app_version %></p>
       </div>
     </div>
   </div><!-- /.container -->

--- a/config/configuration_singleton.rb
+++ b/config/configuration_singleton.rb
@@ -28,7 +28,7 @@ class ConfigurationSingleton
 
   # @return [String] memoized version string
   def app_version
-    @app_version ||= (version_from_file('.') || version_from_git('.') || "Unknown").strip
+    @app_version ||= (version_from_file(Rails.root) || version_from_git(Rails.root) || "Unknown").strip
   end
 
   # @return [String] memoized version string
@@ -49,7 +49,7 @@ class ConfigurationSingleton
   # @return [String, nil] version string from VERSION file, or nil if no file avail
   def version_from_file(dir)
     Dir.chdir(Pathname.new(dir)) do
-      file = Rails.root.join("VERSION")
+      file = Pathname.new("VERSION")
       file.read if file.file?
     end
   rescue Errno::ENOENT

--- a/config/configuration_singleton.rb
+++ b/config/configuration_singleton.rb
@@ -27,20 +27,33 @@ class ConfigurationSingleton
   alias_method :app_sharing_facls_enabled?, :app_sharing_facls_enabled
 
   # @return [String] memoized version string
-  def version
-    @version ||= (version_from_file || version_from_git || "No version string available").strip
+  def app_version
+    @app_version ||= (version_from_file('.') || version_from_git('.') || "Unknown").strip
+  end
+
+  # @return [String] memoized version string
+  def ood_version
+    @ood_version ||= (ood_version_from_env || version_from_file('/opt/ood') || version_from_git('/opt/ood') || "Unknown").strip
   end
 
   # @return [String, nil] version string from git describe, or nil if not git repo
-  def version_from_git
-    version = `git describe --always --tags`
-    version.blank? ? nil : version
+  def version_from_git(dir)
+    Dir.chdir(Pathname.new(dir)) do
+      version = `git describe --always --tags`
+      version.blank? ? nil : version
+    end
   end
 
   # @return [String, nil] version string from VERSION file, or nil if no file avail
-  def version_from_file
-    file = Rails.root.join("VERSION")
-    file.read if file.file?
+  def version_from_file(dir)
+    Dir.chdir(Pathname.new(dir)) do
+      file = Rails.root.join("VERSION")
+      file.read if file.file?
+    end
+  end
+
+  def ood_version_from_env
+    ENV['OOD_VERSION'] || ENV['ONDEMAND_VERSION']
   end
 
   # The app's configuration root directory

--- a/config/configuration_singleton.rb
+++ b/config/configuration_singleton.rb
@@ -39,9 +39,11 @@ class ConfigurationSingleton
   # @return [String, nil] version string from git describe, or nil if not git repo
   def version_from_git(dir)
     Dir.chdir(Pathname.new(dir)) do
-      version = `git describe --always --tags`
+      version = `git describe --always --tags 2>/dev/null`
       version.blank? ? nil : version
     end
+  rescue Errno::ENOENT
+    nil
   end
 
   # @return [String, nil] version string from VERSION file, or nil if no file avail
@@ -50,6 +52,8 @@ class ConfigurationSingleton
       file = Rails.root.join("VERSION")
       file.read if file.file?
     end
+  rescue Errno::ENOENT
+    nil
   end
 
   def ood_version_from_env

--- a/config/configuration_singleton.rb
+++ b/config/configuration_singleton.rb
@@ -48,12 +48,8 @@ class ConfigurationSingleton
 
   # @return [String, nil] version string from VERSION file, or nil if no file avail
   def version_from_file(dir)
-    Dir.chdir(Pathname.new(dir)) do
-      file = Pathname.new("VERSION")
-      file.read if file.file?
-    end
-  rescue Errno::ENOENT
-    nil
+    file = Pathname.new(dir).join("VERSION")
+    file.read if file.file?
   end
 
   def ood_version_from_env


### PR DESCRIPTION
The OnDemand version falls back like so:

- Environment `OOD_VERSION`
- Environment `ONDEMAND_VERSION`
- Version file at `/opt/ood`
- Git describe at `/opt/ood`
- Unknown

I chose to change 'No version available' to 'Unknown' since we are already calling it out as the version.

![ood-app-versions](https://user-images.githubusercontent.com/13316545/55492263-f31af980-5604-11e9-890c-87aa55630418.png)


Fixes #457.