### PR TITLE
Quality Setting Manipulation in NoVNC

### DIFF
--- a/app/views/batch_connect/sessions/connections/_novnc.html.erb
+++ b/app/views/batch_connect/sessions/connections/_novnc.html.erb
@@ -1,2 +1,16 @@
-<%= link_to icon('fas', 'eye', t('dashboard.tr.batch_connect_sessions_novnc_launch', app_title: app_title)), novnc_link(connect), class: 'btn btn-primary', target: '_blank' %>
+<%= form_tag(asset_path("noVNC-1.0.0/vnc.html"), method: "get") do %>
+ <%= hidden_field_tag(:autoconnect, 'true') %>
+ <%= hidden_field_tag(:path, "rnode/#{connect.host}/#{connect.websocket}/websockify") %>
+ <%= hidden_field_tag(:resize, "remote") %>
+ <%= hidden_field_tag(:password, connect.password) %>
+ <p>Compression Setting: (-255 Low Compression, -247 High Compression)</p>
+ <%= text_field_tag(:compressionsetting) %>
+  <br />
+ <p>Quality Setting: (-32 Low Quality, -23 High Quality)</p>
+ <%= text_field_tag(:qualitysetting) %>
+<br />
+<br />
+ <%= submit_tag("Connect") %>
+<% end %>
+
 <%= link_to t('dashboard.tr.batch_connect_sessions_novnc_view_only'), novnc_link(connect, view_only: true), class: 'btn btn-default pull-right', target: '_blank' %>

--- a/app/views/batch_connect/sessions/connections/_novnc.html.erb
+++ b/app/views/batch_connect/sessions/connections/_novnc.html.erb
@@ -10,7 +10,7 @@
  <%= text_field_tag(:qualitysetting) %>
 <br />
 <br />
- <%= submit_tag("Connect") %>
+ <%= submit_tag("Connect", :formtarget => "_blank") %>
 <% end %>
 
 <%= link_to t('dashboard.tr.batch_connect_sessions_novnc_view_only'), novnc_link(connect, view_only: true), class: 'btn btn-default pull-right', target: '_blank' %>

--- a/public/noVNC-1.0.0/app.js
+++ b/public/noVNC-1.0.0/app.js
@@ -7497,6 +7497,20 @@ RFB.prototype = {
     _sendEncodings: function () {
         var encs = [];
 
+        //URLSearchParams parses through the query string in search bar
+        var urlParams = new URLSearchParams(window.location.search);
+
+        var qualityLevelDefault = _encodings.encodings.psuedoEncodingQualityLevel0 + 6;
+        
+        var compressionLevelDefault = _encodings.encodings.psuedoEncodingCompressLevel0 + 2;
+
+        //get the compression level query string or use set default if query returns null
+        var compressionLevel = urlParams.get('compressionsetting') || compressionLevelDefault; 
+
+        //get the quality level query string or use set default if query returns null
+        var qualityLevel = urlParams.get('qualitysetting') || qualityLevelDefault;
+
+
         // In preference order
         encs.push(_encodings.encodings.encodingCopyRect);
         // Only supported with full depth support
@@ -7509,8 +7523,8 @@ RFB.prototype = {
 
         // Psuedo-encoding settings
         encs.push(_encodings.encodings.pseudoEncodingTightPNG);
-        encs.push(_encodings.encodings.pseudoEncodingQualityLevel0 + 6);
-        encs.push(_encodings.encodings.pseudoEncodingCompressLevel0 + 2);
+        encs.push(qualityLevel);
+        encs.push(compressionLevel);
 
         encs.push(_encodings.encodings.pseudoEncodingDesktopSize);
         encs.push(_encodings.encodings.pseudoEncodingLastRect);

--- a/public/noVNC-1.0.0/app.js
+++ b/public/noVNC-1.0.0/app.js
@@ -7500,9 +7500,9 @@ RFB.prototype = {
         //URLSearchParams parses through the query string in search bar
         var urlParams = new URLSearchParams(window.location.search);
 
-        var qualityLevelDefault = _encodings.encodings.psuedoEncodingQualityLevel0 + 6;
+        var qualityLevelDefault = _encodings.encodings.pseudoEncodingQualityLevel0 + 6;
         
-        var compressionLevelDefault = _encodings.encodings.psuedoEncodingCompressLevel0 + 2;
+        var compressionLevelDefault = _encodings.encodings.pseudoEncodingCompressLevel0 + 2;
 
         //get the compression level query string or use set default if query returns null
         var compressionLevel = urlParams.get('compressionsetting') || compressionLevelDefault; 


### PR DESCRIPTION
I have added the query strings to manipulate the compression level and the quality level. If no compression and quality levels are provided in the query it just uses the defaults.