### PR TITLE
Improve default dev mode enabling

### DIFF
--- a/config/configuration_singleton.rb
+++ b/config/configuration_singleton.rb
@@ -130,7 +130,7 @@ class ConfigurationSingleton
 
   def app_development_enabled?
     return @app_development_enabled if defined? @app_development_enabled
-    to_bool(ENV['OOD_APP_DEVELOPMENT'] || DevRouter.base_path.directory?)
+    to_bool(ENV['OOD_APP_DEVELOPMENT'] || DevRouter.base_path.directory? || DevRouter.base_path.symlink?)
   end
   alias_method :app_development_enabled, :app_development_enabled?
 


### PR DESCRIPTION
By default dev enabling in 1.4+ works like shared apps enabling,
where a symlink to the dev directory is created, such as
/var/www/ood/apps/dev/efranz/gatway => ~efranz/ondemand/dev

Before, we only enabled if this directory existed; so after the admin
adds the symlink, the user must create the dev directory.

With this change we enable dev mode if the symlink exists, even if the
corresponding directory has not yet been created. Since the dashboard
will create the directory if it doesn't yet exist when navigating to it,
this removes an extra step to enabling dev mode in the dashboard.