### PR TITLE
Support an arbirary link inside the Help dropdown

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,6 +39,10 @@ module ApplicationHelper
     ENV['OOD_DASHBOARD_PASSWD_URL']
   end
 
+  def help_custom_url
+    ENV['OOD_DASHBOARD_HELP_CUSTOM_URL']
+  end
+
   def fa_icon(icon, fa_style: "fas", id: "")
     content_tag(:i, "", id: id, class: [fa_style, "fa-#{icon}", "fa-fw", "app-icon"] , title: "FontAwesome icon specified: #{icon}")
   end

--- a/app/views/layouts/nav/_help_dropdown.html.erb
+++ b/app/views/layouts/nav/_help_dropdown.html.erb
@@ -7,6 +7,7 @@
     <%= nav_link(t('dashboard.nav_help_docs'), "info-circle", docs_url, target: "_blank") %>
     <%= nav_link(t('dashboard.nav_help_change_password'), "key", passwd_url, target: "_blank") %>
     <%= nav_link(t('dashboard.nav_help_two_factor'), "mobile-alt", configure_2fa_url, target: "_blank") %>
+    <%= nav_link(t('dashboard.nav_help_custom'), "question-circle", help_custom_url, target: "_blank" ) %>
     <%= nav_link(t('dashboard.nav_restart_server'), "sync", restart_url) %>
   </ul>
 </li>

--- a/app/views/layouts/nav/_help_dropdown.html.erb
+++ b/app/views/layouts/nav/_help_dropdown.html.erb
@@ -7,7 +7,9 @@
     <%= nav_link(t('dashboard.nav_help_docs'), "info-circle", docs_url, target: "_blank") %>
     <%= nav_link(t('dashboard.nav_help_change_password'), "key", passwd_url, target: "_blank") %>
     <%= nav_link(t('dashboard.nav_help_two_factor'), "mobile-alt", configure_2fa_url, target: "_blank") %>
-    <%= nav_link(t('dashboard.nav_help_custom'), "question-circle", help_custom_url, target: "_blank" ) %>
+    <%- if help_custom_url -%>
+      <%= nav_link(t('dashboard.nav_help_custom'), "question-circle", help_custom_url, target: "_blank" ) %>
+    <%- end -%>
     <%= nav_link(t('dashboard.nav_restart_server'), "sync", restart_url) %>
   </ul>
 </li>


### PR DESCRIPTION
The idea would be to provide a link to Keycloak account page so people can more easily get to page that allows them to remove their CILogon mapping.